### PR TITLE
Add directUrl to Prisma datasource for Neon

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DATABASE_URL_UNPOOLED")
 }
 
 model User {


### PR DESCRIPTION
## Summary
Adds `directUrl` to the Prisma datasource so migrations work against Neon's connection pooler.

Neon's pooled `DATABASE_URL` routes through pgbouncer in transaction mode, which doesn't support the prepared statements that `prisma migrate` / `prisma db push` need. `directUrl` points at the unpooled connection so migrations open a direct session.

## Test plan
- [x] `npx prisma generate` succeeds locally without `DATABASE_URL_UNPOOLED` set (env var only validated when directUrl is actually used)
- [ ] After merge: `DATABASE_URL="<unpooled>" npx prisma db push` succeeds against Neon
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)