### PR TITLE
Add change-password flow on profile page

### DIFF
--- a/src/__tests__/components/ProfilePage.test.tsx
+++ b/src/__tests__/components/ProfilePage.test.tsx
@@ -156,4 +156,89 @@ describe("ProfilePage", () => {
       expect(screen.getByText(/unable to load profile/i)).toBeInTheDocument();
     });
   });
+
+  it("renders the change password form", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ user: mockUser }),
+    });
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/current password/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText(/^new password$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm new password/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /change password/i })).toBeInTheDocument();
+  });
+
+  it("submits POST to /api/auth/change-password with the form values", async () => {
+    const user = userEvent.setup();
+
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ user: mockUser }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/current password/i)).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText(/current password/i), "oldpw123");
+    await user.type(screen.getByLabelText(/^new password$/i), "newpw456");
+    await user.type(screen.getByLabelText(/confirm new password/i), "newpw456");
+    await user.click(screen.getByRole("button", { name: /change password/i }));
+
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls;
+      const passwordCall = calls.find((c) => c[0] === "/api/auth/change-password");
+      expect(passwordCall).toBeDefined();
+    });
+
+    const passwordCall = (global.fetch as jest.Mock).mock.calls.find(
+      (c) => c[0] === "/api/auth/change-password"
+    );
+    expect(passwordCall![1].method).toBe("POST");
+    const body = JSON.parse(passwordCall![1].body);
+    expect(body.currentPassword).toBe("oldpw123");
+    expect(body.newPassword).toBe("newpw456");
+    expect(body.confirmNewPassword).toBe("newpw456");
+  });
+
+  it("shows error when confirmation does not match new password", async () => {
+    const user = userEvent.setup();
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ user: mockUser }),
+    });
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/current password/i)).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText(/current password/i), "oldpw123");
+    await user.type(screen.getByLabelText(/^new password$/i), "newpw456");
+    await user.type(screen.getByLabelText(/confirm new password/i), "different");
+    await user.click(screen.getByRole("button", { name: /change password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument();
+    });
+
+    // Should NOT have called the API
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    expect(calls.find((c) => c[0] === "/api/auth/change-password")).toBeUndefined();
+  });
 });

--- a/src/__tests__/lib/validations.test.ts
+++ b/src/__tests__/lib/validations.test.ts
@@ -1,4 +1,9 @@
-import { updateProfileSchema, addMemberSchema, updateMemberSchema } from "@/lib/validations";
+import {
+  updateProfileSchema,
+  addMemberSchema,
+  updateMemberSchema,
+  changePasswordSchema,
+} from "@/lib/validations";
 
 describe("updateProfileSchema", () => {
   it("accepts a valid name", () => {
@@ -88,5 +93,56 @@ describe("updateMemberSchema", () => {
 
   it("rejects missing role", () => {
     expect(updateMemberSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("changePasswordSchema", () => {
+  const validInput = {
+    currentPassword: "oldpassword",
+    newPassword: "newpassword123",
+    confirmNewPassword: "newpassword123",
+  };
+
+  it("accepts valid input where new password matches confirmation", () => {
+    expect(changePasswordSchema.safeParse(validInput).success).toBe(true);
+  });
+
+  it("rejects when new password is shorter than 6 characters", () => {
+    expect(
+      changePasswordSchema.safeParse({
+        ...validInput,
+        newPassword: "short",
+        confirmNewPassword: "short",
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects when confirmation does not match new password", () => {
+    expect(
+      changePasswordSchema.safeParse({
+        ...validInput,
+        confirmNewPassword: "different-password",
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects when new password equals current password", () => {
+    expect(
+      changePasswordSchema.safeParse({
+        currentPassword: "samepassword",
+        newPassword: "samepassword",
+        confirmNewPassword: "samepassword",
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects empty current password", () => {
+    expect(
+      changePasswordSchema.safeParse({ ...validInput, currentPassword: "" }).success
+    ).toBe(false);
+  });
+
+  it("rejects missing fields", () => {
+    expect(changePasswordSchema.safeParse({}).success).toBe(false);
   });
 });

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { updateProfileSchema, UpdateProfileInput } from "@/lib/validations";
+import {
+  updateProfileSchema,
+  UpdateProfileInput,
+  changePasswordSchema,
+  ChangePasswordInput,
+} from "@/lib/validations";
 import { Avatar, Badge, Button, Input } from "@/components/ui";
 import { User } from "@/types";
 import { formatDate } from "@/lib/utils";
@@ -15,6 +20,9 @@ export default function ProfilePage() {
   const [success, setSuccess] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [passwordError, setPasswordError] = useState("");
+  const [passwordSuccess, setPasswordSuccess] = useState("");
+  const [isChangingPassword, setIsChangingPassword] = useState(false);
 
   const {
     register,
@@ -23,6 +31,15 @@ export default function ProfilePage() {
     reset,
   } = useForm<UpdateProfileInput>({
     resolver: zodResolver(updateProfileSchema),
+  });
+
+  const {
+    register: registerPassword,
+    handleSubmit: handleSubmitPassword,
+    formState: { errors: passwordErrors },
+    reset: resetPassword,
+  } = useForm<ChangePasswordInput>({
+    resolver: zodResolver(changePasswordSchema),
   });
 
   useEffect(() => {
@@ -72,6 +89,38 @@ export default function ProfilePage() {
       setError("An error occurred. Please try again.");
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  const onSubmitPassword = async (data: ChangePasswordInput) => {
+    setIsChangingPassword(true);
+    setPasswordError("");
+    setPasswordSuccess("");
+
+    try {
+      const res = await fetch("/api/auth/change-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+
+      const result = await res.json();
+
+      if (!res.ok) {
+        setPasswordError(result.error || "Failed to change password");
+        return;
+      }
+
+      setPasswordSuccess("Password changed successfully");
+      resetPassword({
+        currentPassword: "",
+        newPassword: "",
+        confirmNewPassword: "",
+      });
+    } catch {
+      setPasswordError("An error occurred. Please try again.");
+    } finally {
+      setIsChangingPassword(false);
     }
   };
 
@@ -195,6 +244,64 @@ export default function ProfilePage() {
             </div>
           </form>
         </div>
+      </div>
+
+      {/* Change password */}
+      <div className="bg-white rounded-2xl border border-orange-100 shadow-sm mt-6">
+        <div className="border-b border-orange-100 px-8 py-6">
+          <h2 className="text-xl font-bold text-gray-900">Change Password</h2>
+          <p className="text-sm text-gray-500 mt-1">
+            Use a strong password — at least 6 characters and different from your
+            current one.
+          </p>
+        </div>
+
+        <form
+          onSubmit={handleSubmitPassword(onSubmitPassword)}
+          className="p-8 space-y-4"
+        >
+          {passwordError && (
+            <div className="rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-600">
+              {passwordError}
+            </div>
+          )}
+          {passwordSuccess && (
+            <div className="rounded-xl bg-green-50 border border-green-200 p-3 text-sm text-green-700">
+              {passwordSuccess}
+            </div>
+          )}
+
+          <Input
+            id="currentPassword"
+            type="password"
+            label="Current Password"
+            autoComplete="current-password"
+            error={passwordErrors.currentPassword?.message}
+            {...registerPassword("currentPassword")}
+          />
+          <Input
+            id="newPassword"
+            type="password"
+            label="New Password"
+            autoComplete="new-password"
+            error={passwordErrors.newPassword?.message}
+            {...registerPassword("newPassword")}
+          />
+          <Input
+            id="confirmNewPassword"
+            type="password"
+            label="Confirm New Password"
+            autoComplete="new-password"
+            error={passwordErrors.confirmNewPassword?.message}
+            {...registerPassword("confirmNewPassword")}
+          />
+
+          <div className="flex justify-end pt-2">
+            <Button type="submit" isLoading={isChangingPassword}>
+              Change Password
+            </Button>
+          </div>
+        </form>
       </div>
     </div>
   );

--- a/src/app/api/auth/change-password/route.ts
+++ b/src/app/api/auth/change-password/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import { changePasswordSchema } from "@/lib/validations";
+
+export async function POST(request: NextRequest) {
+  try {
+    const currentUser = await getCurrentUser();
+    if (!currentUser) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const validation = changePasswordSchema.safeParse(body);
+
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: validation.error.errors[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { currentPassword, newPassword } = validation.data;
+
+    const userWithPassword = await prisma.user.findUnique({
+      where: { id: currentUser.id },
+      select: { id: true, password: true },
+    });
+
+    if (!userWithPassword) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const matches = await bcrypt.compare(currentPassword, userWithPassword.password);
+    if (!matches) {
+      return NextResponse.json(
+        { error: "Current password is incorrect" },
+        { status: 400 }
+      );
+    }
+
+    const hashed = await bcrypt.hash(newPassword, 10);
+
+    await prisma.user.update({
+      where: { id: currentUser.id },
+      data: { password: hashed },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Change password error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -88,6 +88,21 @@ export const updateProfileSchema = z
   })
   .strip();
 
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, "Current password is required"),
+    newPassword: z.string().min(6, "Password must be at least 6 characters"),
+    confirmNewPassword: z.string().min(1, "Please confirm the new password"),
+  })
+  .refine((data) => data.newPassword === data.confirmNewPassword, {
+    message: "Passwords do not match",
+    path: ["confirmNewPassword"],
+  })
+  .refine((data) => data.newPassword !== data.currentPassword, {
+    message: "New password must be different from current password",
+    path: ["newPassword"],
+  });
+
 // Type exports
 export type RegisterInput = z.infer<typeof registerSchema>;
 export type LoginInput = z.infer<typeof loginSchema>;
@@ -101,3 +116,4 @@ export type UpdateStatusInput = z.infer<typeof updateStatusSchema>;
 export type AddMemberInput = z.infer<typeof addMemberSchema>;
 export type UpdateMemberInput = z.infer<typeof updateMemberSchema>;
 export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;


### PR DESCRIPTION
## Summary
- New \`POST /api/auth/change-password\` endpoint that verifies current password via bcrypt and rotates the hash
- Profile page gets a "Change Password" section with current / new / confirm fields
- Zod schema enforces 6-char minimum, match between new and confirm, and that new differs from current

## Why
Seeded admin password (\`admin123\`) is in the public repo. Users need a UI to rotate their own credentials.

## Test plan
- [x] 6 schema tests for changePasswordSchema (min length, match, must-differ)
- [x] 3 component tests on ProfilePage (renders, submits POST with body, blocks on mismatch)
- [x] All 58 tests pass locally
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean (warnings only)
- [x] \`npm run build\` succeeds
- [ ] CI passes
- [ ] After merge: rotate the admin password on prod via the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)