### PR TITLE
Vulnerabilities tab + list + filters + report form (PR-B of #11)

### DIFF
--- a/src/__tests__/components/CreateVulnerabilityModal.test.tsx
+++ b/src/__tests__/components/CreateVulnerabilityModal.test.tsx
@@ -1,0 +1,242 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CreateVulnerabilityModal } from "@/components/vulnerabilities/create-vulnerability-modal";
+import { User } from "@/types";
+
+jest.mock("@/components/ui", () => {
+  const React = require("react");
+  return {
+    Modal: ({
+      children,
+      title,
+      isOpen,
+    }: {
+      children: React.ReactNode;
+      title: React.ReactNode;
+      isOpen: boolean;
+    }) =>
+      isOpen ? (
+        <div data-testid="modal">
+          <div data-testid="modal-title">{title}</div>
+          {children}
+        </div>
+      ) : null,
+    Button: React.forwardRef(
+      (
+        {
+          children,
+          isLoading,
+          variant,
+          ...props
+        }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+          children: React.ReactNode;
+          isLoading?: boolean;
+          variant?: string;
+        },
+        ref: React.Ref<HTMLButtonElement>
+      ) => (
+        <button ref={ref} {...props}>
+          {children}
+        </button>
+      )
+    ),
+    Input: React.forwardRef(
+      (
+        {
+          label,
+          error,
+          ...props
+        }: { label?: string; error?: string } &
+          React.InputHTMLAttributes<HTMLInputElement>,
+        ref: React.Ref<HTMLInputElement>
+      ) => (
+        <div>
+          {label && <label htmlFor={props.id}>{label}</label>}
+          <input ref={ref} {...props} />
+          {error && <span role="alert">{error}</span>}
+        </div>
+      )
+    ),
+    Textarea: React.forwardRef(
+      (
+        {
+          label,
+          error,
+          ...props
+        }: { label?: string; error?: string } &
+          React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+        ref: React.Ref<HTMLTextAreaElement>
+      ) => (
+        <div>
+          {label && <label htmlFor={props.id}>{label}</label>}
+          <textarea ref={ref} {...props} />
+          {error && <span role="alert">{error}</span>}
+        </div>
+      )
+    ),
+    Select: React.forwardRef(
+      (
+        {
+          label,
+          options,
+          error,
+          ...props
+        }: {
+          label?: string;
+          error?: string;
+          options: { value: string; label: string }[];
+        } & React.SelectHTMLAttributes<HTMLSelectElement>,
+        ref: React.Ref<HTMLSelectElement>
+      ) => (
+        <div>
+          {label && <label htmlFor={props.id}>{label}</label>}
+          <select ref={ref} {...props}>
+            {options.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )
+    ),
+  };
+});
+
+const members: User[] = [
+  {
+    id: "u1",
+    email: "alice@test.com",
+    name: "Alice",
+    avatarUrl: null,
+    role: "USER",
+    createdAt: new Date(),
+  },
+  {
+    id: "u2",
+    email: "bob@test.com",
+    name: "Bob",
+    avatarUrl: null,
+    role: "USER",
+    createdAt: new Date(),
+  },
+];
+
+describe("CreateVulnerabilityModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock) = jest.fn();
+  });
+
+  it("does not render when closed", () => {
+    render(
+      <CreateVulnerabilityModal
+        isOpen={false}
+        onClose={jest.fn()}
+        projectId="p1"
+        members={members}
+        onCreated={jest.fn()}
+      />
+    );
+    expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+  });
+
+  it("renders required fields when open", () => {
+    render(
+      <CreateVulnerabilityModal
+        isOpen={true}
+        onClose={jest.fn()}
+        projectId="p1"
+        members={members}
+        onCreated={jest.fn()}
+      />
+    );
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/severity/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/cve id/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/ghsa id/i)).toBeInTheDocument();
+  });
+
+  it("submits the form and calls onCreated with the new vulnerability", async () => {
+    const onCreated = jest.fn();
+    const newVuln = { id: "v1", title: "RCE", severity: "HIGH" };
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ vulnerability: newVuln }),
+    });
+
+    const user = userEvent.setup();
+    render(
+      <CreateVulnerabilityModal
+        isOpen={true}
+        onClose={jest.fn()}
+        projectId="p1"
+        members={members}
+        onCreated={onCreated}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/title/i), "RCE in foo");
+    await user.selectOptions(screen.getByLabelText(/severity/i), "HIGH");
+    await user.click(screen.getByRole("button", { name: /report vulnerability/i }));
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith(newVuln);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/projects/p1/vulnerabilities",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("displays a server error when the API call fails", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Only project admins can report vulnerabilities" }),
+    });
+
+    const user = userEvent.setup();
+    render(
+      <CreateVulnerabilityModal
+        isOpen={true}
+        onClose={jest.fn()}
+        projectId="p1"
+        members={members}
+        onCreated={jest.fn()}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/title/i), "Bad");
+    await user.selectOptions(screen.getByLabelText(/severity/i), "LOW");
+    await user.click(screen.getByRole("button", { name: /report vulnerability/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/only project admins can report vulnerabilities/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("rejects an invalid CVE id format on the client", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateVulnerabilityModal
+        isOpen={true}
+        onClose={jest.fn()}
+        projectId="p1"
+        members={members}
+        onCreated={jest.fn()}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/title/i), "X");
+    await user.selectOptions(screen.getByLabelText(/severity/i), "LOW");
+    await user.type(screen.getByLabelText(/cve id/i), "not-a-cve");
+    await user.click(screen.getByRole("button", { name: /report vulnerability/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/components/ProjectTabs.test.tsx
+++ b/src/__tests__/components/ProjectTabs.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { ProjectTabs } from "@/components/projects/project-tabs";
+
+jest.mock("next/link", () => {
+  const MockLink = ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    href: string;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  );
+  MockLink.displayName = "MockLink";
+  return MockLink;
+});
+
+describe("ProjectTabs", () => {
+  it("renders Board and Vulnerabilities tabs", () => {
+    render(<ProjectTabs projectId="p1" active="board" />);
+    expect(screen.getByRole("link", { name: /board/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /vulnerabilities/i })
+    ).toBeInTheDocument();
+  });
+
+  it("links Board to the project root", () => {
+    render(<ProjectTabs projectId="p1" active="board" />);
+    expect(screen.getByRole("link", { name: /board/i })).toHaveAttribute(
+      "href",
+      "/projects/p1"
+    );
+  });
+
+  it("links Vulnerabilities to the vulnerabilities sub-route", () => {
+    render(<ProjectTabs projectId="p1" active="vulnerabilities" />);
+    expect(
+      screen.getByRole("link", { name: /vulnerabilities/i })
+    ).toHaveAttribute("href", "/projects/p1/vulnerabilities");
+  });
+
+  it("marks the active tab with aria-current", () => {
+    render(<ProjectTabs projectId="p1" active="board" />);
+    expect(screen.getByRole("link", { name: /board/i })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(
+      screen.getByRole("link", { name: /vulnerabilities/i })
+    ).not.toHaveAttribute("aria-current", "page");
+  });
+
+  it("highlights the vulnerabilities tab when active", () => {
+    render(<ProjectTabs projectId="p1" active="vulnerabilities" />);
+    expect(
+      screen.getByRole("link", { name: /vulnerabilities/i })
+    ).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/src/__tests__/components/VulnerabilitiesList.test.tsx
+++ b/src/__tests__/components/VulnerabilitiesList.test.tsx
@@ -1,0 +1,237 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { VulnerabilitiesList } from "@/components/vulnerabilities/vulnerabilities-list";
+import { Vulnerability, User, Role } from "@/types";
+
+jest.mock("@/components/vulnerabilities/create-vulnerability-modal", () => ({
+  CreateVulnerabilityModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="create-modal" /> : null,
+}));
+
+const reporter: User = {
+  id: "u1",
+  email: "alice@test.com",
+  name: "Alice",
+  avatarUrl: null,
+  role: "USER",
+  createdAt: new Date(),
+};
+
+const me: User = {
+  id: "me",
+  email: "me@test.com",
+  name: "Me",
+  avatarUrl: null,
+  role: "USER",
+  createdAt: new Date(),
+};
+
+function vuln(overrides: Partial<Vulnerability>): Vulnerability {
+  return {
+    id: "v1",
+    projectId: "p1",
+    title: "RCE",
+    description: null,
+    cveId: null,
+    ghsaId: null,
+    severity: "HIGH",
+    cvssScore: null,
+    cvssVector: null,
+    exploitStatus: "UNKNOWN",
+    affectedComponent: null,
+    affectedVersions: null,
+    fixedVersion: null,
+    status: "OPEN",
+    reportedAt: new Date("2026-05-01"),
+    patchedAt: null,
+    verifiedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    reporterId: reporter.id,
+    assigneeId: null,
+    reporter,
+    assignee: null,
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  projectId: "p1",
+  members: [reporter, me],
+  currentUser: me,
+  myRole: "ADMIN" as Role,
+};
+
+describe("VulnerabilitiesList", () => {
+  it("renders an empty state when there are no vulnerabilities", () => {
+    render(<VulnerabilitiesList {...baseProps} initialVulnerabilities={[]} />);
+    expect(screen.getByText(/no vulnerabilities/i)).toBeInTheDocument();
+  });
+
+  it("renders one row per vulnerability", () => {
+    const vulns = [
+      vuln({ id: "v1", title: "RCE in foo" }),
+      vuln({ id: "v2", title: "XSS in bar", severity: "MEDIUM" }),
+    ];
+    render(
+      <VulnerabilitiesList {...baseProps} initialVulnerabilities={vulns} />
+    );
+    expect(screen.getByText("RCE in foo")).toBeInTheDocument();
+    expect(screen.getByText("XSS in bar")).toBeInTheDocument();
+  });
+
+  it("sorts by CVSS score descending by default", () => {
+    const vulns = [
+      vuln({ id: "v1", title: "Lower", cvssScore: 5.0 }),
+      vuln({ id: "v2", title: "Higher", cvssScore: 9.8 }),
+      vuln({ id: "v3", title: "Mid", cvssScore: 7.5 }),
+    ];
+    render(
+      <VulnerabilitiesList {...baseProps} initialVulnerabilities={vulns} />
+    );
+    const rows = screen.getAllByTestId("vuln-row");
+    expect(rows[0]).toHaveTextContent("Higher");
+    expect(rows[1]).toHaveTextContent("Mid");
+    expect(rows[2]).toHaveTextContent("Lower");
+  });
+
+  it("filters by severity", async () => {
+    const user = userEvent.setup();
+    const vulns = [
+      vuln({ id: "v1", title: "Critical thing", severity: "CRITICAL" }),
+      vuln({ id: "v2", title: "Low thing", severity: "LOW" }),
+    ];
+    render(
+      <VulnerabilitiesList {...baseProps} initialVulnerabilities={vulns} />
+    );
+
+    expect(screen.getByText("Critical thing")).toBeInTheDocument();
+    expect(screen.getByText("Low thing")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^critical$/i }));
+
+    expect(screen.getByText("Critical thing")).toBeInTheDocument();
+    expect(screen.queryByText("Low thing")).not.toBeInTheDocument();
+  });
+
+  it("filters by status", async () => {
+    const user = userEvent.setup();
+    const vulns = [
+      vuln({ id: "v1", title: "Open thing", status: "OPEN" }),
+      vuln({ id: "v2", title: "Patched thing", status: "PATCHED" }),
+    ];
+    render(
+      <VulnerabilitiesList {...baseProps} initialVulnerabilities={vulns} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^open$/i }));
+
+    expect(screen.getByText("Open thing")).toBeInTheDocument();
+    expect(screen.queryByText("Patched thing")).not.toBeInTheDocument();
+  });
+
+  it("toggles assigned-to-me filter", async () => {
+    const user = userEvent.setup();
+    const vulns = [
+      vuln({ id: "v1", title: "Mine", assigneeId: me.id, assignee: me }),
+      vuln({
+        id: "v2",
+        title: "Theirs",
+        assigneeId: reporter.id,
+        assignee: reporter,
+      }),
+    ];
+    render(
+      <VulnerabilitiesList {...baseProps} initialVulnerabilities={vulns} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /assigned to me/i }));
+
+    expect(screen.getByText("Mine")).toBeInTheDocument();
+    expect(screen.queryByText("Theirs")).not.toBeInTheDocument();
+  });
+
+  it("filters by has-CVE", async () => {
+    const user = userEvent.setup();
+    const vulns = [
+      vuln({ id: "v1", title: "With CVE", cveId: "CVE-2025-1" }),
+      vuln({ id: "v2", title: "Without CVE", cveId: null }),
+    ];
+    render(
+      <VulnerabilitiesList {...baseProps} initialVulnerabilities={vulns} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /has cve/i }));
+
+    expect(screen.getByText("With CVE")).toBeInTheDocument();
+    expect(screen.queryByText("Without CVE")).not.toBeInTheDocument();
+  });
+
+  it("clears all filters", async () => {
+    const user = userEvent.setup();
+    const vulns = [
+      vuln({ id: "v1", title: "Critical thing", severity: "CRITICAL" }),
+      vuln({ id: "v2", title: "Low thing", severity: "LOW" }),
+    ];
+    render(
+      <VulnerabilitiesList {...baseProps} initialVulnerabilities={vulns} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^critical$/i }));
+    expect(screen.queryByText("Low thing")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /clear/i }));
+
+    expect(screen.getByText("Low thing")).toBeInTheDocument();
+  });
+
+  it("shows the report button for project admins", () => {
+    render(
+      <VulnerabilitiesList
+        {...baseProps}
+        myRole="ADMIN"
+        initialVulnerabilities={[]}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /report vulnerability/i })
+    ).toBeInTheDocument();
+  });
+
+  it("hides the report button for regular project members", () => {
+    render(
+      <VulnerabilitiesList
+        {...baseProps}
+        myRole="MEMBER"
+        initialVulnerabilities={[]}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /report vulnerability/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the create modal when the report button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <VulnerabilitiesList
+        {...baseProps}
+        myRole="ADMIN"
+        initialVulnerabilities={[]}
+      />
+    );
+    expect(screen.queryByTestId("create-modal")).not.toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: /report vulnerability/i })
+    );
+    expect(screen.getByTestId("create-modal")).toBeInTheDocument();
+  });
+
+  it("shows CVE id when present", () => {
+    const vulns = [vuln({ cveId: "CVE-2025-1234" })];
+    render(
+      <VulnerabilitiesList {...baseProps} initialVulnerabilities={vulns} />
+    );
+    expect(screen.getByText("CVE-2025-1234")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/VulnerabilityBadges.test.tsx
+++ b/src/__tests__/components/VulnerabilityBadges.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { SeverityBadge } from "@/components/vulnerabilities/severity-badge";
+import { StatusBadge } from "@/components/vulnerabilities/status-badge";
+import { ExploitBadge } from "@/components/vulnerabilities/exploit-badge";
+
+describe("SeverityBadge", () => {
+  it.each(["LOW", "MEDIUM", "HIGH", "CRITICAL"] as const)(
+    "renders %s",
+    (severity) => {
+      render(<SeverityBadge severity={severity} />);
+      expect(
+        screen.getByText(severity, { exact: false })
+      ).toBeInTheDocument();
+    }
+  );
+
+  it("uses red styling for CRITICAL", () => {
+    const { container } = render(<SeverityBadge severity="CRITICAL" />);
+    expect(container.firstChild).toHaveClass(/red/);
+  });
+
+  it("uses orange styling for HIGH", () => {
+    const { container } = render(<SeverityBadge severity="HIGH" />);
+    expect(container.firstChild).toHaveClass(/orange/);
+  });
+
+  it("uses gray styling for LOW", () => {
+    const { container } = render(<SeverityBadge severity="LOW" />);
+    expect(container.firstChild).toHaveClass(/gray/);
+  });
+});
+
+describe("StatusBadge", () => {
+  it.each([
+    ["OPEN", /open/i],
+    ["TRIAGED", /triaged/i],
+    ["IN_PROGRESS", /in progress/i],
+    ["PATCHED", /patched/i],
+    ["VERIFIED", /verified/i],
+    ["WONT_FIX", /won't fix/i],
+    ["DUPLICATE", /duplicate/i],
+  ] as const)("renders %s with a human-readable label", (status, label) => {
+    render(<StatusBadge status={status} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+});
+
+describe("ExploitBadge", () => {
+  it("renders nothing for UNKNOWN (default)", () => {
+    const { container } = render(<ExploitBadge exploitStatus="UNKNOWN" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders for IN_THE_WILD with red emphasis", () => {
+    const { container } = render(<ExploitBadge exploitStatus="IN_THE_WILD" />);
+    expect(container).not.toBeEmptyDOMElement();
+    expect(container.firstChild).toHaveClass(/red/);
+  });
+
+  it("renders POC label", () => {
+    render(<ExploitBadge exploitStatus="POC" />);
+    expect(screen.getByText(/poc/i)).toBeInTheDocument();
+  });
+
+  it("renders THEORETICAL label", () => {
+    render(<ExploitBadge exploitStatus="THEORETICAL" />);
+    expect(screen.getByText(/theoretical/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/src/app/(dashboard)/projects/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { Board } from "@/components/board/board";
+import { ProjectTabs } from "@/components/projects/project-tabs";
 
 export default async function ProjectPage({
   params,
@@ -74,6 +75,11 @@ export default async function ProjectPage({
           Settings
         </Link>
       </div>
+
+      <div className="mb-6">
+        <ProjectTabs projectId={project.id} active="board" />
+      </div>
+
       <Board
         project={project}
         initialTasks={tasks}

--- a/src/app/(dashboard)/projects/[id]/vulnerabilities/page.tsx
+++ b/src/app/(dashboard)/projects/[id]/vulnerabilities/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import { ProjectTabs } from "@/components/projects/project-tabs";
+import { VulnerabilitiesList } from "@/components/vulnerabilities/vulnerabilities-list";
+
+const userSelect = {
+  id: true,
+  email: true,
+  name: true,
+  avatarUrl: true,
+  role: true,
+  createdAt: true,
+} as const;
+
+export default async function ProjectVulnerabilitiesPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { id } = await params;
+
+  const project = await prisma.project.findFirst({
+    where: { id, members: { some: { userId: user.id } } },
+    include: {
+      members: { include: { user: { select: userSelect } } },
+    },
+  });
+
+  if (!project) {
+    notFound();
+  }
+
+  const myMembership = project.members.find((m) => m.userId === user.id);
+  if (!myMembership) {
+    notFound();
+  }
+
+  const vulnerabilities = await prisma.vulnerability.findMany({
+    where: { projectId: id },
+    include: {
+      reporter: { select: userSelect },
+      assignee: { select: userSelect },
+    },
+    orderBy: [{ severity: "desc" }, { reportedAt: "desc" }],
+  });
+
+  return (
+    <div className="h-full">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{project.name}</h1>
+          <p className="text-sm text-orange-500 font-medium mt-1">
+            {project.key}
+          </p>
+        </div>
+        <Link
+          href={`/projects/${project.id}/settings`}
+          className="inline-flex items-center gap-2 rounded-xl border border-orange-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-orange-50 hover:border-orange-300 transition-colors"
+        >
+          Settings
+        </Link>
+      </div>
+
+      <div className="mb-6">
+        <ProjectTabs projectId={project.id} active="vulnerabilities" />
+      </div>
+
+      <VulnerabilitiesList
+        projectId={project.id}
+        members={project.members.map((m) => m.user)}
+        currentUser={{
+          ...user,
+          createdAt: user.createdAt,
+        }}
+        myRole={myMembership.role}
+        initialVulnerabilities={vulnerabilities}
+      />
+    </div>
+  );
+}

--- a/src/components/projects/project-tabs.tsx
+++ b/src/components/projects/project-tabs.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+type Tab = "board" | "vulnerabilities";
+
+interface Props {
+  projectId: string;
+  active: Tab;
+}
+
+const TABS: { id: Tab; label: string; path: (id: string) => string }[] = [
+  { id: "board", label: "Board", path: (id) => `/projects/${id}` },
+  {
+    id: "vulnerabilities",
+    label: "Vulnerabilities",
+    path: (id) => `/projects/${id}/vulnerabilities`,
+  },
+];
+
+export function ProjectTabs({ projectId, active }: Props) {
+  return (
+    <nav className="border-b border-orange-100">
+      <ul className="flex gap-1 -mb-px">
+        {TABS.map((tab) => {
+          const isActive = active === tab.id;
+          return (
+            <li key={tab.id}>
+              <Link
+                href={tab.path(projectId)}
+                aria-current={isActive ? "page" : undefined}
+                className={`inline-block px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                  isActive
+                    ? "border-orange-500 text-orange-600"
+                    : "border-transparent text-gray-600 hover:text-orange-600 hover:border-orange-200"
+                }`}
+              >
+                {tab.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/vulnerabilities/create-vulnerability-modal.tsx
+++ b/src/components/vulnerabilities/create-vulnerability-modal.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  createVulnerabilitySchema,
+  CreateVulnerabilityInput,
+} from "@/lib/validations";
+import { Modal, Button, Input, Textarea, Select } from "@/components/ui";
+import { User, Vulnerability } from "@/types";
+
+const emptyToUndefined = (v: unknown) =>
+  v === "" || v === null || v === undefined ? undefined : v;
+
+interface CreateVulnerabilityModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  projectId: string;
+  members: User[];
+  onCreated: (vulnerability: Vulnerability) => void;
+}
+
+export function CreateVulnerabilityModal({
+  isOpen,
+  onClose,
+  projectId,
+  members,
+  onCreated,
+}: CreateVulnerabilityModalProps) {
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<CreateVulnerabilityInput>({
+    resolver: zodResolver(createVulnerabilitySchema),
+    defaultValues: { severity: "MEDIUM", exploitStatus: "UNKNOWN" },
+  });
+
+  const onSubmit = async (data: CreateVulnerabilityInput) => {
+    setIsLoading(true);
+    setError("");
+
+    // Strip empty optional strings so server-side regex validation
+    // doesn't run against "" (which fails CVE/GHSA pattern).
+    const cleaned: Record<string, unknown> = { ...data };
+    for (const key of Object.keys(cleaned)) {
+      if (cleaned[key] === "") delete cleaned[key];
+    }
+
+    try {
+      const res = await fetch(`/api/projects/${projectId}/vulnerabilities`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(cleaned),
+      });
+
+      const result = await res.json();
+
+      if (!res.ok) {
+        setError(result.error || "Failed to report vulnerability");
+        return;
+      }
+
+      onCreated(result.vulnerability);
+      reset();
+    } catch {
+      setError("An error occurred. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    reset();
+    setError("");
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="Report a vulnerability">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        {error && (
+          <div className="rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-600">
+            {error}
+          </div>
+        )}
+
+        <Input
+          id="title"
+          label="Title"
+          placeholder="Short summary"
+          error={errors.title?.message}
+          {...register("title")}
+        />
+
+        <Textarea
+          id="description"
+          label="Description"
+          placeholder="Impact, affected endpoints, reproduction steps..."
+          error={errors.description?.message}
+          {...register("description")}
+        />
+
+        <Select
+          id="severity"
+          label="Severity"
+          options={[
+            { value: "LOW", label: "Low" },
+            { value: "MEDIUM", label: "Medium" },
+            { value: "HIGH", label: "High" },
+            { value: "CRITICAL", label: "Critical" },
+          ]}
+          {...register("severity")}
+        />
+
+        <div className="grid grid-cols-2 gap-3">
+          <Input
+            id="cveId"
+            label="CVE id"
+            placeholder="CVE-2025-12345"
+            error={errors.cveId?.message}
+            {...register("cveId", { setValueAs: emptyToUndefined })}
+          />
+          <Input
+            id="ghsaId"
+            label="GHSA id"
+            placeholder="GHSA-xxxx-xxxx-xxxx"
+            error={errors.ghsaId?.message}
+            {...register("ghsaId", { setValueAs: emptyToUndefined })}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Input
+            id="cvssScore"
+            label="CVSS score"
+            type="number"
+            step="0.1"
+            min="0"
+            max="10"
+            placeholder="0.0 - 10.0"
+            error={errors.cvssScore?.message}
+            {...register("cvssScore", {
+              setValueAs: (v) =>
+                v === "" || v === null || v === undefined
+                  ? undefined
+                  : Number(v),
+            })}
+          />
+          <Select
+            id="exploitStatus"
+            label="Exploit status"
+            options={[
+              { value: "UNKNOWN", label: "Unknown" },
+              { value: "THEORETICAL", label: "Theoretical" },
+              { value: "POC", label: "Proof of concept" },
+              { value: "IN_THE_WILD", label: "In the wild" },
+            ]}
+            {...register("exploitStatus")}
+          />
+        </div>
+
+        <Input
+          id="affectedComponent"
+          label="Affected component"
+          placeholder="e.g. next@14.2.5"
+          error={errors.affectedComponent?.message}
+          {...register("affectedComponent")}
+        />
+
+        <div className="grid grid-cols-2 gap-3">
+          <Input
+            id="affectedVersions"
+            label="Affected versions"
+            placeholder="< 14.2.35"
+            error={errors.affectedVersions?.message}
+            {...register("affectedVersions")}
+          />
+          <Input
+            id="fixedVersion"
+            label="Fixed version"
+            placeholder="14.2.35"
+            error={errors.fixedVersion?.message}
+            {...register("fixedVersion")}
+          />
+        </div>
+
+        <Select
+          id="assigneeId"
+          label="Assignee"
+          options={[
+            { value: "", label: "Unassigned" },
+            ...members.map((m) => ({ value: m.id, label: m.name })),
+          ]}
+          {...register("assigneeId")}
+        />
+
+        <div className="flex justify-end gap-3 pt-4">
+          <Button type="button" variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button type="submit" isLoading={isLoading}>
+            Report vulnerability
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/vulnerabilities/exploit-badge.tsx
+++ b/src/components/vulnerabilities/exploit-badge.tsx
@@ -1,0 +1,31 @@
+import { ExploitStatus } from "@/types";
+
+const STYLES: Partial<Record<ExploitStatus, string>> = {
+  THEORETICAL: "bg-gray-100 text-gray-700 border-gray-200",
+  POC: "bg-amber-100 text-amber-700 border-amber-200",
+  IN_THE_WILD: "bg-red-100 text-red-700 border-red-200",
+};
+
+const LABELS: Partial<Record<ExploitStatus, string>> = {
+  THEORETICAL: "Theoretical",
+  POC: "PoC",
+  IN_THE_WILD: "In the wild",
+};
+
+export function ExploitBadge({
+  exploitStatus,
+}: {
+  exploitStatus: ExploitStatus;
+}) {
+  if (exploitStatus === "UNKNOWN") return null;
+  const style = STYLES[exploitStatus];
+  const label = LABELS[exploitStatus];
+  if (!style || !label) return null;
+  return (
+    <span
+      className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${style}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/vulnerabilities/severity-badge.tsx
+++ b/src/components/vulnerabilities/severity-badge.tsx
@@ -1,0 +1,25 @@
+import { VulnSeverity } from "@/types";
+
+const STYLES: Record<VulnSeverity, string> = {
+  LOW: "bg-gray-100 text-gray-700 border-gray-200",
+  MEDIUM: "bg-amber-100 text-amber-700 border-amber-200",
+  HIGH: "bg-orange-100 text-orange-700 border-orange-200",
+  CRITICAL: "bg-red-100 text-red-700 border-red-200",
+};
+
+const LABELS: Record<VulnSeverity, string> = {
+  LOW: "Low",
+  MEDIUM: "Medium",
+  HIGH: "High",
+  CRITICAL: "Critical",
+};
+
+export function SeverityBadge({ severity }: { severity: VulnSeverity }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${STYLES[severity]}`}
+    >
+      {LABELS[severity]}
+    </span>
+  );
+}

--- a/src/components/vulnerabilities/status-badge.tsx
+++ b/src/components/vulnerabilities/status-badge.tsx
@@ -1,0 +1,31 @@
+import { VulnStatus } from "@/types";
+
+const STYLES: Record<VulnStatus, string> = {
+  OPEN: "bg-red-50 text-red-700 border-red-200",
+  TRIAGED: "bg-orange-50 text-orange-700 border-orange-200",
+  IN_PROGRESS: "bg-amber-50 text-amber-700 border-amber-200",
+  PATCHED: "bg-blue-50 text-blue-700 border-blue-200",
+  VERIFIED: "bg-green-50 text-green-700 border-green-200",
+  WONT_FIX: "bg-gray-100 text-gray-600 border-gray-200",
+  DUPLICATE: "bg-gray-100 text-gray-600 border-gray-200",
+};
+
+const LABELS: Record<VulnStatus, string> = {
+  OPEN: "Open",
+  TRIAGED: "Triaged",
+  IN_PROGRESS: "In progress",
+  PATCHED: "Patched",
+  VERIFIED: "Verified",
+  WONT_FIX: "Won't fix",
+  DUPLICATE: "Duplicate",
+};
+
+export function StatusBadge({ status }: { status: VulnStatus }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium ${STYLES[status]}`}
+    >
+      {LABELS[status]}
+    </span>
+  );
+}

--- a/src/components/vulnerabilities/vulnerabilities-list.tsx
+++ b/src/components/vulnerabilities/vulnerabilities-list.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui";
+import { Role, User, Vulnerability, VulnSeverity, VulnStatus } from "@/types";
+import { SeverityBadge } from "./severity-badge";
+import { StatusBadge } from "./status-badge";
+import { ExploitBadge } from "./exploit-badge";
+import { CreateVulnerabilityModal } from "./create-vulnerability-modal";
+
+interface Props {
+  projectId: string;
+  members: User[];
+  currentUser: User;
+  myRole: Role;
+  initialVulnerabilities: Vulnerability[];
+}
+
+const ALL_SEVERITIES: VulnSeverity[] = ["CRITICAL", "HIGH", "MEDIUM", "LOW"];
+const ALL_STATUSES: VulnStatus[] = [
+  "OPEN",
+  "TRIAGED",
+  "IN_PROGRESS",
+  "PATCHED",
+  "VERIFIED",
+  "WONT_FIX",
+  "DUPLICATE",
+];
+
+const STATUS_LABELS: Record<VulnStatus, string> = {
+  OPEN: "Open",
+  TRIAGED: "Triaged",
+  IN_PROGRESS: "In progress",
+  PATCHED: "Patched",
+  VERIFIED: "Verified",
+  WONT_FIX: "Won't fix",
+  DUPLICATE: "Duplicate",
+};
+
+export function VulnerabilitiesList({
+  projectId,
+  members,
+  currentUser,
+  myRole,
+  initialVulnerabilities,
+}: Props) {
+  const [vulns, setVulns] = useState(initialVulnerabilities);
+  const [severityFilter, setSeverityFilter] = useState<Set<VulnSeverity>>(
+    new Set()
+  );
+  const [statusFilter, setStatusFilter] = useState<Set<VulnStatus>>(new Set());
+  const [hasCveOnly, setHasCveOnly] = useState(false);
+  const [assignedToMeOnly, setAssignedToMeOnly] = useState(false);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+
+  const isAdmin = myRole === "ADMIN";
+
+  const visible = useMemo(() => {
+    let list = [...vulns];
+    if (severityFilter.size > 0) {
+      list = list.filter((v) => severityFilter.has(v.severity));
+    }
+    if (statusFilter.size > 0) {
+      list = list.filter((v) => statusFilter.has(v.status));
+    }
+    if (hasCveOnly) {
+      list = list.filter((v) => !!v.cveId);
+    }
+    if (assignedToMeOnly) {
+      list = list.filter((v) => v.assigneeId === currentUser.id);
+    }
+    list.sort((a, b) => {
+      const aScore = a.cvssScore ?? -1;
+      const bScore = b.cvssScore ?? -1;
+      return bScore - aScore;
+    });
+    return list;
+  }, [
+    vulns,
+    severityFilter,
+    statusFilter,
+    hasCveOnly,
+    assignedToMeOnly,
+    currentUser.id,
+  ]);
+
+  const toggle = <T,>(set: Set<T>, value: T): Set<T> => {
+    const next = new Set(set);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    return next;
+  };
+
+  const activeFilterCount =
+    severityFilter.size +
+    statusFilter.size +
+    (hasCveOnly ? 1 : 0) +
+    (assignedToMeOnly ? 1 : 0);
+
+  const clearFilters = () => {
+    setSeverityFilter(new Set());
+    setStatusFilter(new Set());
+    setHasCveOnly(false);
+    setAssignedToMeOnly(false);
+  };
+
+  const handleCreated = (v: Vulnerability) => {
+    setVulns([v, ...vulns]);
+    setIsCreateOpen(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold text-gray-900">
+          Vulnerabilities{" "}
+          <span className="text-sm font-normal text-gray-500">
+            ({visible.length} of {vulns.length})
+          </span>
+        </h2>
+        {isAdmin && (
+          <Button onClick={() => setIsCreateOpen(true)}>
+            + Report vulnerability
+          </Button>
+        )}
+      </div>
+
+      <div className="rounded-2xl border border-orange-100 bg-white p-4 shadow-sm space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+            Severity
+          </span>
+          {ALL_SEVERITIES.map((s) => (
+            <FilterPill
+              key={s}
+              label={s.charAt(0) + s.slice(1).toLowerCase()}
+              active={severityFilter.has(s)}
+              onClick={() => setSeverityFilter(toggle(severityFilter, s))}
+            />
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+            Status
+          </span>
+          {ALL_STATUSES.map((s) => (
+            <FilterPill
+              key={s}
+              label={STATUS_LABELS[s]}
+              active={statusFilter.has(s)}
+              onClick={() => setStatusFilter(toggle(statusFilter, s))}
+            />
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <FilterPill
+            label="Has CVE"
+            active={hasCveOnly}
+            onClick={() => setHasCveOnly(!hasCveOnly)}
+          />
+          <FilterPill
+            label="Assigned to me"
+            active={assignedToMeOnly}
+            onClick={() => setAssignedToMeOnly(!assignedToMeOnly)}
+          />
+          {activeFilterCount > 0 && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="text-xs font-medium text-orange-600 hover:text-orange-700 ml-2"
+            >
+              Clear ({activeFilterCount})
+            </button>
+          )}
+        </div>
+      </div>
+
+      {visible.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-orange-200 bg-orange-50/50 p-12 text-center">
+          <p className="text-gray-700 font-medium">No vulnerabilities</p>
+          <p className="mt-1 text-sm text-gray-500">
+            {vulns.length === 0
+              ? "Nothing's been reported on this project yet."
+              : "No vulnerabilities match the current filters."}
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-orange-100 bg-white shadow-sm divide-y divide-orange-50 overflow-hidden">
+          {visible.map((v) => (
+            <VulnRow key={v.id} vuln={v} />
+          ))}
+        </div>
+      )}
+
+      <CreateVulnerabilityModal
+        isOpen={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+        projectId={projectId}
+        members={members}
+        onCreated={handleCreated}
+      />
+    </div>
+  );
+}
+
+function FilterPill({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+        active
+          ? "border-orange-500 bg-orange-500 text-white"
+          : "border-gray-200 bg-white text-gray-700 hover:border-orange-300 hover:bg-orange-50"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function VulnRow({ vuln }: { vuln: Vulnerability }) {
+  return (
+    <div data-testid="vuln-row" className="p-4 hover:bg-orange-50/50 transition-colors">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <SeverityBadge severity={vuln.severity} />
+            <StatusBadge status={vuln.status} />
+            <ExploitBadge exploitStatus={vuln.exploitStatus} />
+            {vuln.cveId && (
+              <span className="text-xs font-mono text-gray-500">
+                {vuln.cveId}
+              </span>
+            )}
+            {vuln.ghsaId && !vuln.cveId && (
+              <span className="text-xs font-mono text-gray-500">
+                {vuln.ghsaId}
+              </span>
+            )}
+          </div>
+          <div className="mt-2 font-medium text-gray-900 truncate">
+            {vuln.title}
+          </div>
+          {vuln.affectedComponent && (
+            <div className="mt-1 text-xs text-gray-500 font-mono">
+              {vuln.affectedComponent}
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col items-end gap-1 text-xs text-gray-500 whitespace-nowrap">
+          {vuln.cvssScore !== null && (
+            <span className="font-semibold text-gray-700">
+              CVSS {vuln.cvssScore.toFixed(1)}
+            </span>
+          )}
+          {vuln.assignee && <span>{vuln.assignee.name}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,13 @@
-import { Priority, Role, SystemRole } from "@prisma/client";
+import {
+  Priority,
+  Role,
+  SystemRole,
+  VulnSeverity,
+  VulnStatus,
+  ExploitStatus,
+} from "@prisma/client";
 
-export type { Priority, Role, SystemRole };
+export type { Priority, Role, SystemRole, VulnSeverity, VulnStatus, ExploitStatus };
 
 export interface User {
   id: string;
@@ -67,6 +74,32 @@ export interface Task {
 export interface BoardColumn {
   status: Status;
   tasks: Task[];
+}
+
+export interface Vulnerability {
+  id: string;
+  projectId: string;
+  title: string;
+  description: string | null;
+  cveId: string | null;
+  ghsaId: string | null;
+  severity: VulnSeverity;
+  cvssScore: number | null;
+  cvssVector: string | null;
+  exploitStatus: ExploitStatus;
+  affectedComponent: string | null;
+  affectedVersions: string | null;
+  fixedVersion: string | null;
+  status: VulnStatus;
+  reportedAt: Date;
+  patchedAt: Date | null;
+  verifiedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  reporterId: string;
+  assigneeId: string | null;
+  reporter?: User;
+  assignee?: User | null;
 }
 
 export interface ApiResponse<T> {


### PR DESCRIPTION
## Summary

Second slice of the vulnerability tracking feature. Builds on PR-A (#12) — backend is wired, this adds the user-facing surface.

- New \`Board\` / \`Vulnerabilities\` tab strip at the top of every project page
- New route \`/projects/[id]/vulnerabilities\` listing all reports for the project
- Filtering: severity (multi), status (multi), has-CVE, assigned-to-me, default sort by CVSS desc
- Color-coded severity / status / exploit-status badges
- \"Report a vulnerability\" modal — project ADMINs only, mirrors the create-task pattern, full client-side + server-side validation
- 40 new component tests; 180 / 180 tests pass overall

Status-change UI and the detail page land in PR-C; comments in PR-D.

## What you'll see

- Open any project → tabs appear above the board
- Click \"Vulnerabilities\" → empty state if none, or a sorted list with filter pills
- As an ADMIN: \"+ Report vulnerability\" button opens a modal with title, severity, CVE/GHSA, CVSS, exploit status, affected component / versions / fixed version, assignee
- As a regular MEMBER: read-only view, no report button

## Components added

| File | Purpose |
| --- | --- |
| \`projects/project-tabs.tsx\` | Board / Vulnerabilities nav, marks active with \`aria-current\` |
| \`vulnerabilities/severity-badge.tsx\` | LOW / MEDIUM / HIGH / CRITICAL pill, color-coded |
| \`vulnerabilities/status-badge.tsx\` | OPEN → VERIFIED + WONT_FIX / DUPLICATE pill |
| \`vulnerabilities/exploit-badge.tsx\` | THEORETICAL / POC / IN_THE_WILD (hides for UNKNOWN) |
| \`vulnerabilities/create-vulnerability-modal.tsx\` | Report form with react-hook-form + zod |
| \`vulnerabilities/vulnerabilities-list.tsx\` | List with filter pills, sort, empty states, modal trigger |

## Test plan

- [x] \`npm test\` — 180 / 180 pass (was 140)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean (only pre-existing warnings)
- [x] \`npm run build\` — clean, new route compiled
- [ ] CI green on this PR
- [ ] Manual smoke: load \`/projects/{id}/vulnerabilities\`, click filters, open report modal as admin, submit with valid + invalid inputs

## Out of scope (follow-ups)

- Status-change UI (state machine is enforced server-side already from PR-A) — PR-C
- Detail page with full metadata + comment thread — PR-C / PR-D
- URL-encoded filter state for shareable links — explicit follow-up
- Search box — out of scope per the issue's PR-B description

Tracks #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)