### PR TITLE
Vulnerability detail page + status transitions (PR-C of #11)

### DIFF
--- a/src/__tests__/components/StatusChanger.test.tsx
+++ b/src/__tests__/components/StatusChanger.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StatusChanger } from "@/components/vulnerabilities/status-changer";
+
+describe("StatusChanger", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock) = jest.fn();
+  });
+
+  it("renders the current status as a non-interactive badge for non-admins", () => {
+    render(
+      <StatusChanger
+        projectId="p1"
+        vulnId="v1"
+        currentStatus="OPEN"
+        canEdit={false}
+        onStatusChanged={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/^open$/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /change status/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a Change status button for admins", () => {
+    render(
+      <StatusChanger
+        projectId="p1"
+        vulnId="v1"
+        currentStatus="OPEN"
+        canEdit={true}
+        onStatusChanged={jest.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /change status/i })
+    ).toBeInTheDocument();
+  });
+
+  it("opens a menu showing only valid transitions for the current status", async () => {
+    const user = userEvent.setup();
+    render(
+      <StatusChanger
+        projectId="p1"
+        vulnId="v1"
+        currentStatus="OPEN"
+        canEdit={true}
+        onStatusChanged={jest.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /change status/i }));
+
+    // OPEN can go to TRIAGED, WONT_FIX, DUPLICATE
+    expect(screen.getByRole("menuitem", { name: /triaged/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /won't fix/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /duplicate/i })).toBeInTheDocument();
+    // OPEN cannot go directly to PATCHED, VERIFIED
+    expect(screen.queryByRole("menuitem", { name: /patched/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /verified/i })).not.toBeInTheDocument();
+  });
+
+  it("shows a 'no further transitions' state for terminal statuses", async () => {
+    const user = userEvent.setup();
+    render(
+      <StatusChanger
+        projectId="p1"
+        vulnId="v1"
+        currentStatus="VERIFIED"
+        canEdit={true}
+        onStatusChanged={jest.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /change status/i }));
+    expect(screen.getByText(/no further transitions/i)).toBeInTheDocument();
+  });
+
+  it("PATCHes the vuln on selection and calls onStatusChanged", async () => {
+    const onStatusChanged = jest.fn();
+    const updated = { id: "v1", status: "TRIAGED" };
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ vulnerability: updated }),
+    });
+
+    const user = userEvent.setup();
+    render(
+      <StatusChanger
+        projectId="p1"
+        vulnId="v1"
+        currentStatus="OPEN"
+        canEdit={true}
+        onStatusChanged={onStatusChanged}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /change status/i }));
+    await user.click(screen.getByRole("menuitem", { name: /triaged/i }));
+
+    await waitFor(() => {
+      expect(onStatusChanged).toHaveBeenCalledWith(updated);
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/projects/p1/vulnerabilities/v1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ status: "TRIAGED" }),
+      })
+    );
+  });
+
+  it("surfaces a server error when the PATCH fails", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Invalid status transition: OPEN → VERIFIED" }),
+    });
+
+    const user = userEvent.setup();
+    render(
+      <StatusChanger
+        projectId="p1"
+        vulnId="v1"
+        currentStatus="OPEN"
+        canEdit={true}
+        onStatusChanged={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /change status/i }));
+    await user.click(screen.getByRole("menuitem", { name: /triaged/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/invalid status/i);
+    });
+  });
+});

--- a/src/__tests__/components/VulnerabilitiesList.test.tsx
+++ b/src/__tests__/components/VulnerabilitiesList.test.tsx
@@ -234,4 +234,15 @@ describe("VulnerabilitiesList", () => {
     );
     expect(screen.getByText("CVE-2025-1234")).toBeInTheDocument();
   });
+
+  it("links each row to the detail page", () => {
+    const vulns = [vuln({ id: "v-abc" })];
+    render(
+      <VulnerabilitiesList {...baseProps} initialVulnerabilities={vulns} />
+    );
+    expect(screen.getByTestId("vuln-row")).toHaveAttribute(
+      "href",
+      "/projects/p1/vulnerabilities/v-abc"
+    );
+  });
 });

--- a/src/__tests__/components/VulnerabilityDetail.test.tsx
+++ b/src/__tests__/components/VulnerabilityDetail.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from "@testing-library/react";
+import { VulnerabilityDetail } from "@/components/vulnerabilities/vulnerability-detail";
+import { Vulnerability, User, Role } from "@/types";
+
+jest.mock("@/components/vulnerabilities/status-changer", () => ({
+  StatusChanger: ({
+    currentStatus,
+    canEdit,
+  }: {
+    currentStatus: string;
+    canEdit: boolean;
+  }) => (
+    <div data-testid="status-changer">
+      {currentStatus} {canEdit ? "editable" : "readonly"}
+    </div>
+  ),
+}));
+
+const reporter: User = {
+  id: "u1",
+  email: "alice@test.com",
+  name: "Alice",
+  avatarUrl: null,
+  role: "USER",
+  createdAt: new Date(),
+};
+
+const assignee: User = {
+  id: "u2",
+  email: "bob@test.com",
+  name: "Bob",
+  avatarUrl: null,
+  role: "USER",
+  createdAt: new Date(),
+};
+
+function vuln(overrides: Partial<Vulnerability> = {}): Vulnerability {
+  return {
+    id: "v1",
+    projectId: "p1",
+    title: "RCE in foo-pkg",
+    description: "Remote code execution via deserialization",
+    cveId: "CVE-2025-12345",
+    ghsaId: "GHSA-q4gf-8mx6-v5v3",
+    severity: "HIGH",
+    cvssScore: 8.6,
+    cvssVector: "AV:N/AC:H/PR:L",
+    exploitStatus: "POC",
+    affectedComponent: "foo-pkg@1.2.3",
+    affectedVersions: "< 1.2.4",
+    fixedVersion: "1.2.4",
+    status: "TRIAGED",
+    reportedAt: new Date("2026-04-15T00:00:00Z"),
+    patchedAt: null,
+    verifiedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    reporterId: reporter.id,
+    assigneeId: assignee.id,
+    reporter,
+    assignee,
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  projectId: "p1",
+  myRole: "MEMBER" as Role,
+  onStatusChanged: jest.fn(),
+};
+
+describe("VulnerabilityDetail", () => {
+  it("renders the title", () => {
+    render(<VulnerabilityDetail {...baseProps} vulnerability={vuln()} />);
+    expect(
+      screen.getByRole("heading", { name: /rce in foo-pkg/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders severity, status, and exploit badges", () => {
+    render(<VulnerabilityDetail {...baseProps} vulnerability={vuln()} />);
+    expect(screen.getByText(/^high$/i)).toBeInTheDocument();
+    expect(screen.getByText(/poc/i)).toBeInTheDocument();
+  });
+
+  it("renders the description", () => {
+    render(<VulnerabilityDetail {...baseProps} vulnerability={vuln()} />);
+    expect(
+      screen.getByText(/remote code execution via deserialization/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders both CVE and GHSA ids", () => {
+    render(<VulnerabilityDetail {...baseProps} vulnerability={vuln()} />);
+    expect(screen.getByText("CVE-2025-12345")).toBeInTheDocument();
+    expect(screen.getByText("GHSA-q4gf-8mx6-v5v3")).toBeInTheDocument();
+  });
+
+  it("renders CVSS score and vector", () => {
+    render(<VulnerabilityDetail {...baseProps} vulnerability={vuln()} />);
+    expect(screen.getByText(/8\.6/)).toBeInTheDocument();
+    expect(screen.getByText(/AV:N\/AC:H\/PR:L/)).toBeInTheDocument();
+  });
+
+  it("renders affected component / versions / fix", () => {
+    render(<VulnerabilityDetail {...baseProps} vulnerability={vuln()} />);
+    expect(screen.getByText("foo-pkg@1.2.3")).toBeInTheDocument();
+    expect(screen.getByText("< 1.2.4")).toBeInTheDocument();
+    expect(screen.getByText("1.2.4")).toBeInTheDocument();
+  });
+
+  it("renders the reporter and assignee names", () => {
+    render(<VulnerabilityDetail {...baseProps} vulnerability={vuln()} />);
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("renders 'Unassigned' when no assignee", () => {
+    render(
+      <VulnerabilityDetail
+        {...baseProps}
+        vulnerability={vuln({ assignee: null, assigneeId: null })}
+      />
+    );
+    expect(screen.getByText(/unassigned/i)).toBeInTheDocument();
+  });
+
+  it("passes editable to StatusChanger when role is ADMIN", () => {
+    render(
+      <VulnerabilityDetail
+        {...baseProps}
+        myRole="ADMIN"
+        vulnerability={vuln()}
+      />
+    );
+    expect(screen.getByTestId("status-changer")).toHaveTextContent("editable");
+  });
+
+  it("passes readonly to StatusChanger when role is MEMBER", () => {
+    render(
+      <VulnerabilityDetail
+        {...baseProps}
+        myRole="MEMBER"
+        vulnerability={vuln()}
+      />
+    );
+    expect(screen.getByTestId("status-changer")).toHaveTextContent("readonly");
+  });
+
+  it("hides patchedAt when null", () => {
+    render(<VulnerabilityDetail {...baseProps} vulnerability={vuln()} />);
+    expect(screen.queryByText(/patched on/i)).not.toBeInTheDocument();
+  });
+
+  it("renders patchedAt when present", () => {
+    render(
+      <VulnerabilityDetail
+        {...baseProps}
+        vulnerability={vuln({
+          status: "PATCHED",
+          patchedAt: new Date("2026-04-20T00:00:00Z"),
+        })}
+      />
+    );
+    expect(screen.getByText(/patched on/i)).toBeInTheDocument();
+  });
+
+  it("renders verifiedAt when present", () => {
+    render(
+      <VulnerabilityDetail
+        {...baseProps}
+        vulnerability={vuln({
+          status: "VERIFIED",
+          patchedAt: new Date("2026-04-20T00:00:00Z"),
+          verifiedAt: new Date("2026-04-22T00:00:00Z"),
+        })}
+      />
+    );
+    expect(screen.getByText(/verified on/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/lib/vulnerability-state-machine.test.ts
+++ b/src/__tests__/lib/vulnerability-state-machine.test.ts
@@ -1,6 +1,7 @@
 import {
   canTransition,
   assertTransition,
+  allowedTransitions,
   VulnStatus,
 } from "@/lib/vulnerability-state-machine";
 
@@ -85,6 +86,43 @@ describe("vulnerability state machine", () => {
     it("allows same-state no-op (status unchanged)", () => {
       expect(canTransition("OPEN", "OPEN")).toBe(true);
       expect(canTransition("PATCHED", "PATCHED")).toBe(true);
+    });
+  });
+
+  describe("allowedTransitions", () => {
+    it("returns the valid next states for OPEN", () => {
+      expect(new Set(allowedTransitions("OPEN"))).toEqual(
+        new Set(["TRIAGED", "WONT_FIX", "DUPLICATE"])
+      );
+    });
+
+    it("returns the valid next states for TRIAGED", () => {
+      expect(new Set(allowedTransitions("TRIAGED"))).toEqual(
+        new Set(["IN_PROGRESS", "WONT_FIX", "DUPLICATE"])
+      );
+    });
+
+    it("returns the valid next states for IN_PROGRESS", () => {
+      expect(new Set(allowedTransitions("IN_PROGRESS"))).toEqual(
+        new Set(["PATCHED", "WONT_FIX"])
+      );
+    });
+
+    it("returns the valid next states for PATCHED", () => {
+      expect(new Set(allowedTransitions("PATCHED"))).toEqual(
+        new Set(["VERIFIED", "IN_PROGRESS"])
+      );
+    });
+
+    it("returns an empty list for terminal states", () => {
+      expect(allowedTransitions("VERIFIED")).toEqual([]);
+      expect(allowedTransitions("WONT_FIX")).toEqual([]);
+      expect(allowedTransitions("DUPLICATE")).toEqual([]);
+    });
+
+    it("does not include the current state in the returned list", () => {
+      const targets = allowedTransitions("OPEN");
+      expect(targets).not.toContain("OPEN");
     });
   });
 

--- a/src/app/(dashboard)/projects/[id]/vulnerabilities/[vulnId]/page.tsx
+++ b/src/app/(dashboard)/projects/[id]/vulnerabilities/[vulnId]/page.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import { ProjectTabs } from "@/components/projects/project-tabs";
+import { VulnerabilityDetail } from "@/components/vulnerabilities/vulnerability-detail";
+
+const userSelect = {
+  id: true,
+  email: true,
+  name: true,
+  avatarUrl: true,
+  role: true,
+  createdAt: true,
+} as const;
+
+export default async function VulnerabilityDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string; vulnId: string }>;
+}) {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+
+  const { id, vulnId } = await params;
+
+  const project = await prisma.project.findFirst({
+    where: { id, members: { some: { userId: user.id } } },
+    include: { members: true },
+  });
+  if (!project) notFound();
+
+  const myMembership = project.members.find((m) => m.userId === user.id);
+  if (!myMembership) notFound();
+
+  const vulnerability = await prisma.vulnerability.findFirst({
+    where: { id: vulnId, projectId: id },
+    include: {
+      reporter: { select: userSelect },
+      assignee: { select: userSelect },
+    },
+  });
+  if (!vulnerability) notFound();
+
+  return (
+    <div className="h-full">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{project.name}</h1>
+          <p className="text-sm text-orange-500 font-medium mt-1">
+            {project.key}
+          </p>
+        </div>
+      </div>
+
+      <div className="mb-4">
+        <ProjectTabs projectId={project.id} active="vulnerabilities" />
+      </div>
+
+      <div className="mb-4">
+        <Link
+          href={`/projects/${project.id}/vulnerabilities`}
+          className="text-sm text-orange-600 hover:text-orange-700"
+        >
+          ← Back to vulnerabilities
+        </Link>
+      </div>
+
+      <VulnerabilityDetail
+        projectId={project.id}
+        vulnerability={vulnerability}
+        myRole={myMembership.role}
+      />
+    </div>
+  );
+}

--- a/src/components/vulnerabilities/status-changer.tsx
+++ b/src/components/vulnerabilities/status-changer.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+import { Vulnerability, VulnStatus } from "@/types";
+import { allowedTransitions } from "@/lib/vulnerability-state-machine";
+import { StatusBadge } from "./status-badge";
+
+interface Props {
+  projectId: string;
+  vulnId: string;
+  currentStatus: VulnStatus;
+  canEdit: boolean;
+  onStatusChanged: (vuln: Vulnerability) => void;
+}
+
+const LABELS: Record<VulnStatus, string> = {
+  OPEN: "Open",
+  TRIAGED: "Triaged",
+  IN_PROGRESS: "In progress",
+  PATCHED: "Patched",
+  VERIFIED: "Verified",
+  WONT_FIX: "Won't fix",
+  DUPLICATE: "Duplicate",
+};
+
+export function StatusChanger({
+  projectId,
+  vulnId,
+  currentStatus,
+  canEdit,
+  onStatusChanged,
+}: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [error, setError] = useState("");
+  const [pending, setPending] = useState<VulnStatus | null>(null);
+
+  if (!canEdit) {
+    return <StatusBadge status={currentStatus} />;
+  }
+
+  const targets = allowedTransitions(currentStatus);
+
+  const change = async (target: VulnStatus) => {
+    setPending(target);
+    setError("");
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/vulnerabilities/${vulnId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: target }),
+        }
+      );
+      const result = await res.json();
+      if (!res.ok) {
+        setError(result.error || "Failed to change status");
+        return;
+      }
+      onStatusChanged(result.vulnerability);
+      setIsOpen(false);
+    } catch {
+      setError("An error occurred. Please try again.");
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <StatusBadge status={currentStatus} />
+        <button
+          type="button"
+          onClick={() => setIsOpen((v) => !v)}
+          className="text-xs font-medium text-orange-600 hover:text-orange-700"
+        >
+          Change status
+        </button>
+      </div>
+
+      {isOpen && (
+        <div
+          role="menu"
+          className="rounded-xl border border-orange-100 bg-white shadow-sm overflow-hidden"
+        >
+          {targets.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-gray-500">
+              No further transitions available.
+            </div>
+          ) : (
+            targets.map((target) => (
+              <button
+                key={target}
+                role="menuitem"
+                type="button"
+                disabled={pending !== null}
+                onClick={() => change(target)}
+                className="w-full text-left px-3 py-2 text-sm hover:bg-orange-50 disabled:opacity-50"
+              >
+                Move to {LABELS[target]}
+                {pending === target && (
+                  <span className="ml-2 text-xs text-gray-500">…</span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div role="alert" className="text-xs text-red-600">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/vulnerabilities/vulnerabilities-list.tsx
+++ b/src/components/vulnerabilities/vulnerabilities-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { Button } from "@/components/ui";
 import { Role, User, Vulnerability, VulnSeverity, VulnStatus } from "@/types";
 import { SeverityBadge } from "./severity-badge";
@@ -189,7 +190,7 @@ export function VulnerabilitiesList({
       ) : (
         <div className="rounded-2xl border border-orange-100 bg-white shadow-sm divide-y divide-orange-50 overflow-hidden">
           {visible.map((v) => (
-            <VulnRow key={v.id} vuln={v} />
+            <VulnRow key={v.id} vuln={v} projectId={projectId} />
           ))}
         </div>
       )}
@@ -229,9 +230,13 @@ function FilterPill({
   );
 }
 
-function VulnRow({ vuln }: { vuln: Vulnerability }) {
+function VulnRow({ vuln, projectId }: { vuln: Vulnerability; projectId: string }) {
   return (
-    <div data-testid="vuln-row" className="p-4 hover:bg-orange-50/50 transition-colors">
+    <Link
+      data-testid="vuln-row"
+      href={`/projects/${projectId}/vulnerabilities/${vuln.id}`}
+      className="block p-4 hover:bg-orange-50/50 transition-colors"
+    >
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 flex-wrap">
@@ -267,6 +272,6 @@ function VulnRow({ vuln }: { vuln: Vulnerability }) {
           {vuln.assignee && <span>{vuln.assignee.name}</span>}
         </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/src/components/vulnerabilities/vulnerability-detail.tsx
+++ b/src/components/vulnerabilities/vulnerability-detail.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+import { Role, Vulnerability } from "@/types";
+import { SeverityBadge } from "./severity-badge";
+import { ExploitBadge } from "./exploit-badge";
+import { StatusChanger } from "./status-changer";
+
+interface Props {
+  projectId: string;
+  vulnerability: Vulnerability;
+  myRole: Role;
+  onStatusChanged?: (vuln: Vulnerability) => void;
+}
+
+const formatDate = (d: Date | string) => {
+  const date = typeof d === "string" ? new Date(d) : d;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
+export function VulnerabilityDetail({
+  projectId,
+  vulnerability: initialVuln,
+  myRole,
+  onStatusChanged,
+}: Props) {
+  const [vuln, setVuln] = useState(initialVuln);
+  const isAdmin = myRole === "ADMIN";
+
+  const handleStatusChanged = (updated: Vulnerability) => {
+    setVuln(updated);
+    onStatusChanged?.(updated);
+  };
+
+  return (
+    <div className="grid lg:grid-cols-3 gap-6">
+      <div className="lg:col-span-2 space-y-4">
+        <div>
+          <div className="flex items-center gap-2 flex-wrap mb-3">
+            <SeverityBadge severity={vuln.severity} />
+            <ExploitBadge exploitStatus={vuln.exploitStatus} />
+            {vuln.cveId && (
+              <span className="text-xs font-mono text-gray-600 bg-gray-50 border border-gray-200 rounded-md px-2 py-0.5">
+                {vuln.cveId}
+              </span>
+            )}
+            {vuln.ghsaId && (
+              <span className="text-xs font-mono text-gray-600 bg-gray-50 border border-gray-200 rounded-md px-2 py-0.5">
+                {vuln.ghsaId}
+              </span>
+            )}
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">{vuln.title}</h1>
+        </div>
+
+        {vuln.description && (
+          <section className="rounded-2xl border border-orange-100 bg-white p-5 shadow-sm">
+            <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
+              Description
+            </h2>
+            <p className="text-gray-700 whitespace-pre-wrap">{vuln.description}</p>
+          </section>
+        )}
+
+        {(vuln.affectedComponent ||
+          vuln.affectedVersions ||
+          vuln.fixedVersion) && (
+          <section className="rounded-2xl border border-orange-100 bg-white p-5 shadow-sm">
+            <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-3">
+              Affected
+            </h2>
+            <dl className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+              {vuln.affectedComponent && (
+                <Field label="Component" value={vuln.affectedComponent} mono />
+              )}
+              {vuln.affectedVersions && (
+                <Field
+                  label="Affected versions"
+                  value={vuln.affectedVersions}
+                  mono
+                />
+              )}
+              {vuln.fixedVersion && (
+                <Field label="Fixed in" value={vuln.fixedVersion} mono />
+              )}
+            </dl>
+          </section>
+        )}
+      </div>
+
+      <aside className="space-y-4">
+        <section className="rounded-2xl border border-orange-100 bg-white p-5 shadow-sm space-y-4">
+          <div>
+            <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+              Status
+            </div>
+            <StatusChanger
+              projectId={projectId}
+              vulnId={vuln.id}
+              currentStatus={vuln.status}
+              canEdit={isAdmin}
+              onStatusChanged={handleStatusChanged}
+            />
+          </div>
+
+          <div>
+            <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+              Reporter
+            </div>
+            <div className="text-sm text-gray-800">
+              {vuln.reporter?.name ?? "—"}
+            </div>
+          </div>
+
+          <div>
+            <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+              Assignee
+            </div>
+            <div className="text-sm text-gray-800">
+              {vuln.assignee?.name ?? "Unassigned"}
+            </div>
+          </div>
+
+          {vuln.cvssScore !== null && (
+            <div>
+              <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+                CVSS
+              </div>
+              <div className="text-sm text-gray-800">
+                <span className="font-semibold">{vuln.cvssScore.toFixed(1)}</span>
+                {vuln.cvssVector && (
+                  <span className="ml-2 font-mono text-xs text-gray-500">
+                    {vuln.cvssVector}
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="rounded-2xl border border-orange-100 bg-white p-5 shadow-sm">
+          <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+            Timeline
+          </h2>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li>Reported on {formatDate(vuln.reportedAt)}</li>
+            {vuln.patchedAt && <li>Patched on {formatDate(vuln.patchedAt)}</li>}
+            {vuln.verifiedAt && (
+              <li>Verified on {formatDate(vuln.verifiedAt)}</li>
+            )}
+          </ul>
+        </section>
+      </aside>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div>
+      <dt className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+        {label}
+      </dt>
+      <dd
+        className={`mt-1 text-gray-800 ${mono ? "font-mono text-sm" : "text-sm"}`}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/src/lib/vulnerability-state-machine.ts
+++ b/src/lib/vulnerability-state-machine.ts
@@ -17,6 +17,10 @@ const ALLOWED: Record<VulnStatus, ReadonlyArray<VulnStatus>> = {
   DUPLICATE: [],
 };
 
+export function allowedTransitions(from: VulnStatus): ReadonlyArray<VulnStatus> {
+  return ALLOWED[from];
+}
+
 export function canTransition(from: VulnStatus, to: VulnStatus): boolean {
   if (from === to) return true;
   return ALLOWED[from].includes(to);


### PR DESCRIPTION
## Summary

Third slice of the vulnerability tracking feature. Builds on PR-A (#12, API) and PR-B (#13, list) to give each vulnerability its own page and lets project admins move it through the status lifecycle.

- New route \`/projects/[id]/vulnerabilities/[vulnId]\` showing all metadata: severity, description, CVE/GHSA, CVSS score + vector, affected component / versions / fixed-in, reporter, assignee, and a timeline (reportedAt → patchedAt → verifiedAt)
- New \`StatusChanger\` component — admins only — that opens a menu of *only* the legal next states from the state machine; choosing one PATCHes the API and reflects the new status without a full reload
- Members see a read-only status badge — same component, different mode
- Each row in the list now links to the detail page
- \`allowedTransitions(from)\` added to the state machine helper so the UI can stay in lockstep with the server-side rules

## Component map

| File | Purpose |
| --- | --- |
| \`vulnerabilities/status-changer.tsx\` | Status menu (admin) / badge (member), surfaces server errors |
| \`vulnerabilities/vulnerability-detail.tsx\` | Full metadata + sidebar + timeline |
| \`app/.../vulnerabilities/[vulnId]/page.tsx\` | Server component that loads + role-gates |
| \`lib/vulnerability-state-machine.ts\` | + \`allowedTransitions\` |

## Tests

26 new tests, 206 total, all green.

- 6 for \`allowedTransitions\` (each from-state + terminal cases)
- 6 for \`StatusChanger\` (read-only mode, menu contents respect state machine, server error surfaced, terminal-state empty-menu copy)
- 13 for \`VulnerabilityDetail\` (every metadata block, conditional rendering, role-gating)
- 1 for the new list-row link

## Test plan

- [x] \`npm test\` — 206 / 206
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — new dynamic route registered
- [ ] CI green
- [ ] Manual: open detail page as admin, walk OPEN → TRIAGED → IN_PROGRESS → PATCHED → VERIFIED, confirm \`patchedAt\` / \`verifiedAt\` get stamped (server already does this from PR-A) and timeline updates

## Out of scope

- Comment threads — PR-D
- Inline editing of fields beyond status (severity, assignee, etc.) — explicit follow-up
- Audit log entries for transitions — explicit follow-up

Tracks #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)