### PR TITLE
chore(ci): enforce 80% code coverage on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ on:
   push:
     branches: [main]
 
+# pull-requests: write is needed by the coverage-comment step below to post
+# the coverage summary on PRs. contents stays read-only.
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -42,8 +45,38 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
-      - name: Test
-        run: npm test -- --ci
+      # Runs jest with --coverage; the coverageThreshold configured in
+      # jest.config.js will fail this step if total line/branch/function/
+      # statement coverage drops below the floor. This is the gate.
+      - name: Test (with coverage)
+        run: npm run test:coverage -- --ci
+
+      # Posts/updates a single PR comment summarising total coverage and
+      # per-file deltas vs the base. Only runs on pull_request events; the
+      # action is a no-op on push to main. Failure here must not fail CI —
+      # the gate above is the source of truth.
+      - name: Coverage PR comment
+        if: github.event_name == 'pull_request'
+        uses: MishaKav/jest-coverage-comment@v1.0.27
+        continue-on-error: true
+        with:
+          coverage-summary-path: ./coverage/coverage-summary.json
+          title: Coverage report
+          summary-title: Total coverage
+          badge-title: coverage
+          hide-comment: false
+          create-new-comment: false
+          remove-links-to-files: false
+          remove-links-to-lines: false
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Build
         run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,15 @@ The TDD workflow:
 - Do not skip tests because "it's a small change"
 - Do not mark a task complete until `npm test` passes
 
+#### Coverage gate (enforced by CI)
+
+CI runs `npm run test:coverage` on every PR. Jest is configured with a global
+`coverageThreshold` in `jest.config.js`, so the build fails (locally and in
+CI) if total **lines / branches / functions / statements** drop below the
+threshold. The long-term target is **80%**; the current floor is **35%** and
+will ratchet up over time. Bias toward writing the tests rather than lowering
+the threshold.
+
 ### Tech Stack Notes
 
 - **Next.js 14** (NOT Next.js 16 — params handling differs)

--- a/README.md
+++ b/README.md
@@ -137,6 +137,24 @@ npm run test:watch
 npm run test:coverage
 ```
 
+### Coverage threshold (CI gate)
+
+CI runs `npm run test:coverage` on every pull request. The job fails if any of
+the four global metrics (lines, branches, functions, statements) fall below
+the configured threshold. Thresholds live in
+[`jest.config.js`](./jest.config.js) under `coverageThreshold.global`, so the
+same gate fires locally too.
+
+The current threshold is **35%** across all four metrics. This matches the
+project's current baseline and will be ratcheted up toward the long-term
+target of **80%** as more pages and API routes gain test coverage. See issue
+#6 for the ratchet plan.
+
+A coverage summary is posted as a PR comment on every push and updated in
+place by the
+[MishaKav/jest-coverage-comment](https://github.com/MishaKav/jest-coverage-comment)
+action.
+
 ### Test Structure
 
 ```

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,9 +16,34 @@ const customJestConfig = {
   ],
   collectCoverageFrom: [
     "src/**/*.{js,jsx,ts,tsx}",
-    "!src/**/*.d.ts",
+    // Exclude test files themselves from coverage stats
+    "!src/__tests__/**",
+    // Exclude config files (tooling configuration, not app code)
+    "!**/*.config.{ts,js}",
+    // Exclude TypeScript declaration-only files
+    "!**/*.d.ts",
+    // Exclude generated/migration files outside src (Prisma)
+    "!prisma/**",
+    // Exclude Next.js build output
+    "!.next/**",
+    // Exclude Jest setup file (testing infrastructure, not app code)
+    "!jest.setup.js",
+    // Re-export barrel files contain no executable logic worth measuring
     "!src/**/index.ts",
   ],
+  coverageReporters: ["text", "lcov", "json-summary", "json"],
+  // Coverage gate enforced in CI. Current baseline is ~35% across all four
+  // metrics; thresholds are set to the floor (rounded down to nearest 5%)
+  // per the ratchet strategy in issue #6. Follow-up issue tracks raising
+  // these to 80% as more pages/API routes get test coverage.
+  coverageThreshold: {
+    global: {
+      branches: 35,
+      functions: 35,
+      lines: 35,
+      statements: 35,
+    },
+  },
 };
 
 module.exports = createJestConfig(customJestConfig);


### PR DESCRIPTION
## Summary

Adds a Jest coverage threshold and wires CI to run `npm run test:coverage` on every PR. Closes #6.

- `jest.config.js`: adds `coverageThreshold.global` (lines/branches/functions/statements) plus `collectCoverageFrom` exclusions for tests, configs, `*.d.ts`, `prisma/`, `.next/`, `jest.setup.js`, and barrel `index.ts` files. Each exclusion has an inline comment.
- `coverageReporters` now include `json-summary` so the PR-comment step can parse `coverage/coverage-summary.json`.
- `.github/workflows/ci.yml`: replaces the existing `Test` step with `Test (with coverage)` (the threshold makes Jest itself the gate, so the step fails naturally), posts a coverage summary as a PR comment via `MishaKav/jest-coverage-comment@v1.0.27`, uploads the `coverage/` directory as a workflow artifact, and adds `pull-requests: write` permission for the comment step.
- `README.md` and `CLAUDE.md`: document the gate, the current floor, and the long-term 80% target.

## Baseline coverage (before this change)

Captured locally on `main` with `npm run test:coverage`:

| Metric | Coverage |
| --- | --- |
| Statements | 35.19% |
| Branches | 36.68% |
| Functions | 40.09% |
| Lines | 35.76% |

206 tests across 17 suites all passing.

## Path taken: ratchet (option 2)

The issue lays out two paths and explicitly says "If app code coverage is tiny because lots of pages aren't tested, pick option 2 and ratchet."

That's exactly the situation here:

- Most of `src/app/(dashboard)/...` page components and `src/app/api/...` route handlers have **0%** coverage.
- The well-tested areas (vulnerabilities components, validations, state machine) are already at 80%+, but they account for a small slice of total LOC.
- Closing the gap to 80% would require writing tests for every page route and API handler — a much larger scope than a CI-config PR should carry.

So this PR lands the **mechanism** at the current floor, **35%** (lowest of the four metrics is statements at 35.19%, rounded down to nearest 5%), and a follow-up issue will track ratcheting toward 80% as page/API route tests are added.

The chosen floor leaves zero headroom for regressions — the next PR that drops any metric below 35% will fail CI, which is the intended behaviour.

## Follow-ups

- A new issue to track ratcheting the threshold toward the long-term 80% target. Each round of new tests should bump the floor up by 5%.
- Untested areas to prioritise: `src/app/api/auth/*`, `src/app/api/projects/*` (non-vulnerability), `src/app/api/tasks/*`, `src/components/board/*`, `src/lib/auth.ts`, `src/lib/utils.ts`.

## Branch protection

The new CI step lives inside the existing `Lint, Test, Build` job, so the **required check name does not change** — branch protection on `main` should already cover it. No maintainer action required for the check name itself. If you want the coverage step to be visible as a distinct required check, we can split it into its own job in a follow-up; for now keeping it in one job is simpler and faster.

## Test plan

- [x] `npm test` green (206/206)
- [x] `npm run test:coverage` exits 0 with the new threshold (35% floor met)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [ ] CI workflow runs end-to-end on this PR
- [ ] Coverage comment appears on this PR (and updates in place on subsequent pushes)
- [ ] Verify a deliberately-failing coverage drop fails CI (will validate on the follow-up ratchet PRs)

Local lint shows a pre-existing worktree-only conflict ("Plugin @next/next was conflicted between .eslintrc.json...") because the worktree path `~/workspace/JiraClone/.claude/worktrees/agent-*` sits below the parent repo's own `.eslintrc.json`. Lint runs clean on the actual project root and in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)