### PR TITLE
feat: add personal access tokens for API authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,48 @@ The application uses the following main models:
 | POST | `/api/auth/register` | Register new user |
 | POST | `/api/auth/login` | Login |
 | POST | `/api/auth/logout` | Logout |
-| GET | `/api/auth/me` | Get current user |
+| GET | `/api/auth/me` | Get current user (accepts session cookie or PAT) |
+
+### Personal Access Tokens (PATs)
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/users/me/tokens` | List the current user's active tokens (session-only) |
+| POST | `/api/users/me/tokens` | Create a token, returning the raw value once (session-only) |
+| DELETE | `/api/users/me/tokens/[id]` | Revoke a token (session-only) |
+
+#### Token format
+
+Tokens look like `ll_pat_<32 random base64url bytes>`. The `ll_pat_`
+prefix is identifiable in logs and lets us reject obvious garbage before
+hitting the database. Only a sha256 hash of the token is persisted —
+the raw token is shown to the user exactly once at creation time.
+
+#### Authenticating an API request
+
+Send the token in the `Authorization` header:
+
+```
+Authorization: Bearer ll_pat_<your-token>
+```
+
+PATs grant the same access as the user's UI session. The two exceptions
+are the PAT-management endpoints themselves (create/list/revoke), which
+require a session cookie so a stolen PAT cannot mint or revoke other
+tokens. Revoked tokens are immediately invalid (401).
+
+#### Security notes
+
+- **sha256, not bcrypt**: PATs are 256-bit random secrets — they are not
+  guessable by dictionary attack, so a fast deterministic hash is
+  appropriate. bcrypt would also make every PAT-authenticated request
+  ~100 ms slower.
+- **Constant-time comparison**: hash verification uses
+  `crypto.timingSafeEqual` to avoid leaking the stored hash via timing
+  side channels.
+- **Rate limiting**: token creation is capped at 10 per rolling hour
+  per user (in-memory; per-process for v1).
+- **Last-used timestamps** are updated at most once per minute per token
+  to keep auth path fast.
 
 ### Projects
 | Method | Endpoint | Description |

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,8 +23,27 @@ model User {
   createdTasks            Task[]          @relation("CreatedTasks")
   assignedVulnerabilities Vulnerability[] @relation("VulnAssignee")
   reportedVulnerabilities Vulnerability[] @relation("VulnReporter")
+  personalAccessTokens    PersonalAccessToken[]
 
   @@map("users")
+}
+
+model PersonalAccessToken {
+  id          String    @id @default(cuid())
+  userId      String
+  name        String
+  tokenHash   String    @unique
+  prefix      String
+  scopes      String[]  @default(["*"])
+  lastUsedAt  DateTime?
+  revokedAt   DateTime?
+  createdAt   DateTime  @default(now())
+
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([tokenHash])
+  @@map("personal_access_tokens")
 }
 
 enum SystemRole {

--- a/src/__tests__/api/auth-me-pat.test.ts
+++ b/src/__tests__/api/auth-me-pat.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ *
+ * Tests that an existing protected route (`GET /api/auth/me`) accepts both
+ * session cookies and PATs.
+ */
+
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    personalAccessToken: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/auth", () => {
+  const actual = jest.requireActual("@/lib/auth");
+  return {
+    ...actual,
+    getCurrentUser: jest.fn(),
+  };
+});
+
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import { __resetPATLastUsedCacheForTests } from "@/lib/auth-pat";
+import { generatePersonalAccessToken } from "@/lib/pat";
+import { GET as meGET } from "@/app/api/auth/me/route";
+
+const mockedAuth = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
+const mockedPrisma = prisma as unknown as {
+  personalAccessToken: { findUnique: jest.Mock; update: jest.Mock };
+};
+
+const userRow = {
+  id: "user-1",
+  email: "user@example.com",
+  name: "User",
+  avatarUrl: null,
+  role: "USER" as const,
+  createdAt: new Date("2024-01-01"),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __resetPATLastUsedCacheForTests();
+});
+
+describe("GET /api/auth/me with PAT auth", () => {
+  it("authenticates with a valid PAT in the Authorization header", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const { token, tokenHash } = generatePersonalAccessToken();
+    mockedPrisma.personalAccessToken.findUnique.mockResolvedValue({
+      id: "pat-1",
+      userId: userRow.id,
+      tokenHash,
+      revokedAt: null,
+      lastUsedAt: null,
+      user: userRow,
+    });
+
+    const req = new NextRequest("http://localhost/api/auth/me", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const res = await meGET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user).toEqual(expect.objectContaining({ id: "user-1" }));
+  });
+
+  it("rejects a revoked PAT with 401", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const { token, tokenHash } = generatePersonalAccessToken();
+    mockedPrisma.personalAccessToken.findUnique.mockResolvedValue({
+      id: "pat-1",
+      userId: userRow.id,
+      tokenHash,
+      revokedAt: new Date("2024-02-01"),
+      lastUsedAt: null,
+      user: userRow,
+    });
+
+    const req = new NextRequest("http://localhost/api/auth/me", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const res = await meGET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects malformed bearer tokens with 401", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const req = new NextRequest("http://localhost/api/auth/me", {
+      headers: { authorization: "Bearer not-a-pat" },
+    });
+    const res = await meGET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("still works with a session cookie when no Authorization header is present", async () => {
+    mockedAuth.mockResolvedValue(userRow);
+    const req = new NextRequest("http://localhost/api/auth/me");
+    const res = await meGET(req);
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/__tests__/api/tokens-pat-block.test.ts
+++ b/src/__tests__/api/tokens-pat-block.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ *
+ * PAT-management endpoints must NOT accept PAT auth — only session cookies.
+ * Otherwise, a stolen PAT could be used to mint or revoke other PATs,
+ * making revocation pointless.
+ *
+ * These tests verify the create/list/revoke routes use `getCurrentUser()`
+ * (session-only) rather than `getCurrentUserOrPATUser()`.
+ */
+
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    personalAccessToken: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/pat-rate-limit", () => ({
+  checkAndIncrementCreateRate: jest.fn(() => ({ ok: true, remaining: 9 })),
+}));
+
+import { getCurrentUser } from "@/lib/auth";
+import { POST as createPOST, GET as listGET } from "@/app/api/users/me/tokens/route";
+import { DELETE as revokeDELETE } from "@/app/api/users/me/tokens/[id]/route";
+import { generatePersonalAccessToken } from "@/lib/pat";
+
+const mockedAuth = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Simulate "no session". A PAT in the header must not rescue the request.
+  mockedAuth.mockResolvedValue(null);
+});
+
+describe("PAT routes reject PAT auth (session cookie required)", () => {
+  it("POST /api/users/me/tokens returns 401 even with a Bearer token", async () => {
+    const { token } = generatePersonalAccessToken();
+    const req = new NextRequest("http://localhost/api/users/me/tokens", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ name: "evil" }),
+    });
+    const res = await createPOST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/users/me/tokens returns 401 with a Bearer token (no session)", async () => {
+    const res = await listGET();
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE /api/users/me/tokens/[id] returns 401 with a Bearer token", async () => {
+    const { token } = generatePersonalAccessToken();
+    const req = new NextRequest("http://localhost/api/users/me/tokens/pat-1", {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const res = await revokeDELETE(req, {
+      params: Promise.resolve({ id: "pat-1" }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/__tests__/api/tokens.test.ts
+++ b/src/__tests__/api/tokens.test.ts
@@ -1,0 +1,236 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the PAT management API routes:
+ *   - POST   /api/users/me/tokens     create
+ *   - GET    /api/users/me/tokens     list
+ *   - DELETE /api/users/me/tokens/[id] revoke
+ *
+ * These routes require a session cookie — a stolen PAT must NOT be able
+ * to mint or revoke other PATs.
+ */
+
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    personalAccessToken: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+      count: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/pat-rate-limit", () => ({
+  checkAndIncrementCreateRate: jest.fn(),
+  __resetRateLimiterForTests: jest.fn(),
+}));
+
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import { checkAndIncrementCreateRate } from "@/lib/pat-rate-limit";
+import { GET as listGET, POST as createPOST } from "@/app/api/users/me/tokens/route";
+import { DELETE as revokeDELETE } from "@/app/api/users/me/tokens/[id]/route";
+import { TOKEN_PREFIX } from "@/lib/pat";
+
+const mockedAuth = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
+const mockedRate = checkAndIncrementCreateRate as jest.MockedFunction<
+  typeof checkAndIncrementCreateRate
+>;
+const mockedPrisma = prisma as unknown as {
+  personalAccessToken: {
+    create: jest.Mock;
+    findMany: jest.Mock;
+    findFirst: jest.Mock;
+    update: jest.Mock;
+    count: jest.Mock;
+  };
+};
+
+const userRow = {
+  id: "user-1",
+  email: "user@example.com",
+  name: "User",
+  avatarUrl: null,
+  role: "USER" as const,
+  createdAt: new Date("2024-01-01"),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedRate.mockReturnValue({ ok: true, remaining: 9 });
+});
+
+function jsonRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/users/me/tokens", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function paramsFor(id: string) {
+  return Promise.resolve({ id });
+}
+
+describe("POST /api/users/me/tokens", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const res = await createPOST(jsonRequest({ name: "ci-token" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when name is missing", async () => {
+    mockedAuth.mockResolvedValue(userRow);
+    const res = await createPOST(jsonRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a token, persists only the hash, and returns the raw token once", async () => {
+    mockedAuth.mockResolvedValue(userRow);
+    mockedPrisma.personalAccessToken.create.mockImplementation(
+      async ({ data }: { data: Record<string, unknown> }) => ({
+        id: "pat-1",
+        userId: userRow.id,
+        name: data.name,
+        prefix: data.prefix,
+        scopes: data.scopes ?? ["*"],
+        tokenHash: data.tokenHash,
+        revokedAt: null,
+        lastUsedAt: null,
+        createdAt: new Date("2024-01-02"),
+      })
+    );
+
+    const res = await createPOST(jsonRequest({ name: "ci-token" }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+
+    expect(body.token).toEqual(expect.stringContaining(TOKEN_PREFIX));
+    expect(body.personalAccessToken).toEqual(
+      expect.objectContaining({
+        id: "pat-1",
+        name: "ci-token",
+        prefix: expect.any(String),
+      })
+    );
+    // The persisted record must NEVER include the raw token in plain form
+    const persisted = mockedPrisma.personalAccessToken.create.mock.calls[0][0]
+      .data as Record<string, unknown>;
+    expect(persisted.tokenHash).toEqual(expect.any(String));
+    expect(persisted).not.toHaveProperty("token");
+    expect(typeof persisted.tokenHash).toBe("string");
+    expect(persisted.tokenHash).not.toContain(TOKEN_PREFIX);
+  });
+
+  it("returns 429 when the rate limit has been exceeded", async () => {
+    mockedAuth.mockResolvedValue(userRow);
+    mockedRate.mockReturnValue({ ok: false, remaining: 0 });
+
+    const res = await createPOST(jsonRequest({ name: "ci-token" }));
+    expect(res.status).toBe(429);
+    expect(mockedPrisma.personalAccessToken.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/users/me/tokens", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const res = await listGET();
+    expect(res.status).toBe(401);
+  });
+
+  it("lists active tokens without exposing tokenHash or raw token", async () => {
+    mockedAuth.mockResolvedValue(userRow);
+    mockedPrisma.personalAccessToken.findMany.mockResolvedValue([
+      {
+        id: "pat-1",
+        name: "ci-token",
+        prefix: "abcd1234",
+        scopes: ["*"],
+        lastUsedAt: null,
+        revokedAt: null,
+        createdAt: new Date("2024-01-02"),
+      },
+    ]);
+
+    const res = await listGET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.personalAccessTokens).toHaveLength(1);
+    const t = body.personalAccessTokens[0];
+    expect(t).toEqual(
+      expect.objectContaining({ id: "pat-1", name: "ci-token", prefix: "abcd1234" })
+    );
+    expect(t).not.toHaveProperty("tokenHash");
+    expect(t).not.toHaveProperty("token");
+
+    // The query must filter to the current user and exclude revoked tokens
+    const args = mockedPrisma.personalAccessToken.findMany.mock.calls[0][0];
+    expect(args.where).toEqual(
+      expect.objectContaining({ userId: userRow.id, revokedAt: null })
+    );
+  });
+});
+
+describe("DELETE /api/users/me/tokens/[id]", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const res = await revokeDELETE(
+      new NextRequest("http://localhost/api/users/me/tokens/pat-1", {
+        method: "DELETE",
+      }),
+      { params: paramsFor("pat-1") }
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the token belongs to a different user", async () => {
+    mockedAuth.mockResolvedValue(userRow);
+    mockedPrisma.personalAccessToken.findFirst.mockResolvedValue(null);
+
+    const res = await revokeDELETE(
+      new NextRequest("http://localhost/api/users/me/tokens/pat-1", {
+        method: "DELETE",
+      }),
+      { params: paramsFor("pat-1") }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("soft-deletes (sets revokedAt) when the user owns the token", async () => {
+    mockedAuth.mockResolvedValue(userRow);
+    mockedPrisma.personalAccessToken.findFirst.mockResolvedValue({
+      id: "pat-1",
+      userId: userRow.id,
+      revokedAt: null,
+    });
+    mockedPrisma.personalAccessToken.update.mockResolvedValue({
+      id: "pat-1",
+      userId: userRow.id,
+      revokedAt: new Date("2024-01-03"),
+    });
+
+    const res = await revokeDELETE(
+      new NextRequest("http://localhost/api/users/me/tokens/pat-1", {
+        method: "DELETE",
+      }),
+      { params: paramsFor("pat-1") }
+    );
+    expect(res.status).toBe(200);
+
+    const updateArgs = mockedPrisma.personalAccessToken.update.mock.calls[0][0];
+    expect(updateArgs.where).toEqual({ id: "pat-1" });
+    expect(updateArgs.data).toEqual(
+      expect.objectContaining({ revokedAt: expect.any(Date) })
+    );
+  });
+});

--- a/src/__tests__/components/PersonalAccessTokens.test.tsx
+++ b/src/__tests__/components/PersonalAccessTokens.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PersonalAccessTokens } from "@/components/settings/PersonalAccessTokens";
+
+jest.mock("@/components/ui", () => {
+  const React = require("react");
+  return {
+    Button: React.forwardRef(
+      (
+        {
+          children,
+          variant,
+          size,
+          isLoading,
+          ...props
+        }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+          children: React.ReactNode;
+          variant?: string;
+          size?: string;
+          isLoading?: boolean;
+        },
+        ref: React.Ref<HTMLButtonElement>
+      ) => (
+        <button ref={ref} {...props}>
+          {isLoading ? "Loading..." : children}
+        </button>
+      )
+    ),
+    Input: React.forwardRef(
+      (
+        {
+          label,
+          error,
+          ...props
+        }: { label?: string; error?: string } & React.InputHTMLAttributes<HTMLInputElement>,
+        ref: React.Ref<HTMLInputElement>
+      ) => (
+        <div>
+          {label && <label htmlFor={props.id}>{label}</label>}
+          <input ref={ref} {...props} />
+          {error && <span role="alert">{error}</span>}
+        </div>
+      )
+    ),
+    Modal: ({
+      isOpen,
+      title,
+      children,
+    }: {
+      isOpen: boolean;
+      onClose: () => void;
+      title?: React.ReactNode;
+      children: React.ReactNode;
+    }) =>
+      isOpen ? (
+        <div role="dialog" aria-label={typeof title === "string" ? title : "Modal"}>
+          {title && <div>{title}</div>}
+          {children}
+        </div>
+      ) : null,
+  };
+});
+
+describe("PersonalAccessTokens settings panel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows the empty state with a call to action when the user has no tokens", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ personalAccessTokens: [] }),
+    });
+
+    render(<PersonalAccessTokens />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/create your first token/i)).toBeInTheDocument();
+    });
+  });
+
+  it("lists existing tokens with name, prefix and last-used info", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        personalAccessTokens: [
+          {
+            id: "pat-1",
+            name: "ci-token",
+            prefix: "abcd1234",
+            scopes: ["*"],
+            createdAt: "2024-01-02T00:00:00.000Z",
+            lastUsedAt: null,
+          },
+        ],
+      }),
+    });
+
+    render(<PersonalAccessTokens />);
+
+    await waitFor(() => {
+      expect(screen.getByText("ci-token")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/ll_pat_abcd1234/i)).toBeInTheDocument();
+    expect(screen.getByText(/never used/i)).toBeInTheDocument();
+  });
+
+  it("creates a token, shows it once with the warning, then refreshes the list", async () => {
+    const user = userEvent.setup();
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personalAccessTokens: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          token: "ll_pat_secret_value_xyz",
+          personalAccessToken: {
+            id: "pat-1",
+            name: "ci-token",
+            prefix: "secret_v",
+            scopes: ["*"],
+            createdAt: "2024-01-02T00:00:00.000Z",
+            lastUsedAt: null,
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          personalAccessTokens: [
+            {
+              id: "pat-1",
+              name: "ci-token",
+              prefix: "secret_v",
+              scopes: ["*"],
+              createdAt: "2024-01-02T00:00:00.000Z",
+              lastUsedAt: null,
+            },
+          ],
+        }),
+      });
+
+    render(<PersonalAccessTokens />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/create your first token/i)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /create token/i }));
+    await user.type(screen.getByLabelText(/token name/i), "ci-token");
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("ll_pat_secret_value_xyz")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/copy now — you won't see this again/i)
+    ).toBeInTheDocument();
+
+    // The POST call should have used the right URL and method
+    const postCall = (global.fetch as jest.Mock).mock.calls.find(
+      (c) => c[1]?.method === "POST"
+    );
+    expect(postCall![0]).toBe("/api/users/me/tokens");
+    expect(JSON.parse(postCall![1].body).name).toBe("ci-token");
+  });
+
+  it("revokes a token after confirmation and refreshes the list", async () => {
+    const user = userEvent.setup();
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          personalAccessTokens: [
+            {
+              id: "pat-1",
+              name: "ci-token",
+              prefix: "abcd1234",
+              scopes: ["*"],
+              createdAt: "2024-01-02T00:00:00.000Z",
+              lastUsedAt: null,
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ personalAccessTokens: [] }),
+      });
+
+    render(<PersonalAccessTokens />);
+
+    await waitFor(() => {
+      expect(screen.getByText("ci-token")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /revoke/i }));
+
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls;
+      expect(
+        calls.find((c) => c[0] === "/api/users/me/tokens/pat-1" && c[1]?.method === "DELETE")
+      ).toBeDefined();
+    });
+
+    confirmSpy.mockRestore();
+  });
+});

--- a/src/__tests__/components/ProfilePage.test.tsx
+++ b/src/__tests__/components/ProfilePage.test.tsx
@@ -48,8 +48,30 @@ jest.mock("@/components/ui", () => {
         {children}
       </span>
     ),
+    Modal: ({
+      isOpen,
+      title,
+      children,
+    }: {
+      isOpen: boolean;
+      onClose: () => void;
+      title?: React.ReactNode;
+      children: React.ReactNode;
+    }) =>
+      isOpen ? (
+        <div role="dialog" aria-label={typeof title === "string" ? title : "Modal"}>
+          {title && <div>{title}</div>}
+          {children}
+        </div>
+      ) : null,
   };
 });
+
+// PersonalAccessTokens panel makes its own fetch — stub it so the existing
+// fetch-mock sequences in this file remain accurate.
+jest.mock("@/components/settings/PersonalAccessTokens", () => ({
+  PersonalAccessTokens: () => <div data-testid="pat-panel" />,
+}));
 
 const mockAdmin = {
   id: "admin-1",

--- a/src/__tests__/lib/auth-pat.test.ts
+++ b/src/__tests__/lib/auth-pat.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for `getCurrentUserOrPATUser` — resolves a user from either a
+ * session cookie (existing behavior via `getCurrentUser`) or a PAT in the
+ * Authorization header. Also covers `lastUsedAt` debounced updates.
+ */
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    personalAccessToken: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/auth", () => {
+  const actual = jest.requireActual("@/lib/auth");
+  return {
+    ...actual,
+    getCurrentUser: jest.fn(),
+  };
+});
+
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import {
+  getCurrentUserOrPATUser,
+  __resetPATLastUsedCacheForTests,
+} from "@/lib/auth-pat";
+import { hashToken, generatePersonalAccessToken } from "@/lib/pat";
+
+const mockedPrisma = prisma as unknown as {
+  personalAccessToken: {
+    findUnique: jest.Mock;
+    update: jest.Mock;
+  };
+  user: { findUnique: jest.Mock };
+};
+const mockedGetCurrentUser = getCurrentUser as jest.MockedFunction<
+  typeof getCurrentUser
+>;
+
+const userRow = {
+  id: "user-1",
+  email: "user@example.com",
+  name: "User",
+  avatarUrl: null,
+  role: "USER" as const,
+  createdAt: new Date("2024-01-01"),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __resetPATLastUsedCacheForTests();
+});
+
+function makeRequest(headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/test", { headers });
+}
+
+describe("getCurrentUserOrPATUser", () => {
+  it("falls back to session-based getCurrentUser when no Authorization header is present", async () => {
+    mockedGetCurrentUser.mockResolvedValue(userRow);
+    const result = await getCurrentUserOrPATUser(makeRequest());
+    expect(result).toEqual({ user: userRow, viaPAT: false });
+  });
+
+  it("returns null when neither session nor PAT auth succeeds", async () => {
+    mockedGetCurrentUser.mockResolvedValue(null);
+    const result = await getCurrentUserOrPATUser(makeRequest());
+    expect(result).toBeNull();
+  });
+
+  it("authenticates a user via a valid PAT in the Authorization header", async () => {
+    const { token, tokenHash } = generatePersonalAccessToken();
+
+    mockedPrisma.personalAccessToken.findUnique.mockResolvedValue({
+      id: "pat-1",
+      userId: "user-1",
+      tokenHash,
+      revokedAt: null,
+      lastUsedAt: null,
+      user: userRow,
+    });
+
+    const result = await getCurrentUserOrPATUser(
+      makeRequest({ authorization: `Bearer ${token}` })
+    );
+
+    expect(mockedPrisma.personalAccessToken.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { tokenHash: hashToken(token) } })
+    );
+    expect(result).toEqual({
+      user: expect.objectContaining({ id: "user-1" }),
+      viaPAT: true,
+      tokenId: "pat-1",
+    });
+  });
+
+  it("rejects a revoked PAT (returns null even if session also missing)", async () => {
+    const { token, tokenHash } = generatePersonalAccessToken();
+    mockedGetCurrentUser.mockResolvedValue(null);
+
+    mockedPrisma.personalAccessToken.findUnique.mockResolvedValue({
+      id: "pat-1",
+      userId: "user-1",
+      tokenHash,
+      revokedAt: new Date("2024-01-02"),
+      lastUsedAt: null,
+      user: userRow,
+    });
+
+    const result = await getCurrentUserOrPATUser(
+      makeRequest({ authorization: `Bearer ${token}` })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects a malformed Authorization header", async () => {
+    mockedGetCurrentUser.mockResolvedValue(null);
+    const result = await getCurrentUserOrPATUser(
+      makeRequest({ authorization: "Bearer not-a-real-token" })
+    );
+    expect(result).toBeNull();
+    expect(mockedPrisma.personalAccessToken.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("rejects a token whose hash is not in the database", async () => {
+    const { token } = generatePersonalAccessToken();
+    mockedPrisma.personalAccessToken.findUnique.mockResolvedValue(null);
+
+    const result = await getCurrentUserOrPATUser(
+      makeRequest({ authorization: `Bearer ${token}` })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("updates lastUsedAt on first successful PAT auth", async () => {
+    const { token, tokenHash } = generatePersonalAccessToken();
+    mockedPrisma.personalAccessToken.findUnique.mockResolvedValue({
+      id: "pat-1",
+      userId: "user-1",
+      tokenHash,
+      revokedAt: null,
+      lastUsedAt: null,
+      user: userRow,
+    });
+
+    await getCurrentUserOrPATUser(
+      makeRequest({ authorization: `Bearer ${token}` })
+    );
+
+    expect(mockedPrisma.personalAccessToken.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "pat-1" },
+        data: expect.objectContaining({ lastUsedAt: expect.any(Date) }),
+      })
+    );
+  });
+
+  it("debounces lastUsedAt to at most once per minute per token", async () => {
+    const { token, tokenHash } = generatePersonalAccessToken();
+    mockedPrisma.personalAccessToken.findUnique.mockResolvedValue({
+      id: "pat-1",
+      userId: "user-1",
+      tokenHash,
+      revokedAt: null,
+      lastUsedAt: new Date(),
+      user: userRow,
+    });
+
+    // First call writes lastUsedAt
+    await getCurrentUserOrPATUser(
+      makeRequest({ authorization: `Bearer ${token}` })
+    );
+    // Second call within the debounce window should skip the write
+    await getCurrentUserOrPATUser(
+      makeRequest({ authorization: `Bearer ${token}` })
+    );
+
+    expect(mockedPrisma.personalAccessToken.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/lib/pat-rate-limit.test.ts
+++ b/src/__tests__/lib/pat-rate-limit.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment node
+ *
+ * Tests the in-memory token-bucket rate limiter for PAT creation.
+ * Limit: 10 creations per rolling hour per user.
+ */
+
+import {
+  checkAndIncrementCreateRate,
+  __resetRateLimiterForTests,
+  PAT_CREATE_LIMIT_PER_HOUR,
+} from "@/lib/pat-rate-limit";
+
+beforeEach(() => {
+  __resetRateLimiterForTests();
+});
+
+describe("checkAndIncrementCreateRate", () => {
+  it("allows the first call and decrements remaining", () => {
+    const result = checkAndIncrementCreateRate("user-1");
+    expect(result.ok).toBe(true);
+    expect(result.remaining).toBe(PAT_CREATE_LIMIT_PER_HOUR - 1);
+  });
+
+  it("blocks once the per-hour limit is reached", () => {
+    for (let i = 0; i < PAT_CREATE_LIMIT_PER_HOUR; i += 1) {
+      const r = checkAndIncrementCreateRate("user-1");
+      expect(r.ok).toBe(true);
+    }
+    const blocked = checkAndIncrementCreateRate("user-1");
+    expect(blocked.ok).toBe(false);
+    expect(blocked.remaining).toBe(0);
+  });
+
+  it("isolates buckets per user", () => {
+    for (let i = 0; i < PAT_CREATE_LIMIT_PER_HOUR; i += 1) {
+      checkAndIncrementCreateRate("user-1");
+    }
+    expect(checkAndIncrementCreateRate("user-1").ok).toBe(false);
+    expect(checkAndIncrementCreateRate("user-2").ok).toBe(true);
+  });
+});

--- a/src/__tests__/lib/pat.test.ts
+++ b/src/__tests__/lib/pat.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the Personal Access Token (PAT) library helpers — token generation,
+ * hashing, and verification. The library uses sha256 (not bcrypt): PATs are
+ * 256-bit random secrets, so a fast deterministic hash with constant-time
+ * compare is appropriate.
+ */
+
+import {
+  generatePersonalAccessToken,
+  hashToken,
+  verifyTokenAgainstHash,
+  TOKEN_PREFIX,
+  PUBLIC_PREFIX_LENGTH,
+} from "@/lib/pat";
+
+describe("generatePersonalAccessToken", () => {
+  it("returns a token starting with the ll_pat_ prefix", () => {
+    const { token } = generatePersonalAccessToken();
+    expect(token.startsWith(TOKEN_PREFIX)).toBe(true);
+  });
+
+  it("returns a public prefix exposing the first chars after ll_pat_", () => {
+    const { token, prefix } = generatePersonalAccessToken();
+    const afterPrefix = token.slice(TOKEN_PREFIX.length);
+    expect(prefix).toBe(afterPrefix.slice(0, PUBLIC_PREFIX_LENGTH));
+  });
+
+  it("returns a tokenHash that matches sha256(token)", () => {
+    const { token, tokenHash } = generatePersonalAccessToken();
+    expect(tokenHash).toBe(hashToken(token));
+  });
+
+  it("generates unique tokens across calls", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 25; i += 1) {
+      const { token } = generatePersonalAccessToken();
+      expect(seen.has(token)).toBe(false);
+      seen.add(token);
+    }
+  });
+
+  it("generates a token whose secret portion is base64url (no +, /, =)", () => {
+    const { token } = generatePersonalAccessToken();
+    const secret = token.slice(TOKEN_PREFIX.length);
+    expect(secret).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+});
+
+describe("hashToken", () => {
+  it("is deterministic for the same input", () => {
+    expect(hashToken("ll_pat_abcdef")).toBe(hashToken("ll_pat_abcdef"));
+  });
+
+  it("produces different hashes for different tokens", () => {
+    expect(hashToken("ll_pat_aaa")).not.toBe(hashToken("ll_pat_bbb"));
+  });
+
+  it("returns a 64-char hex string (sha256)", () => {
+    const hash = hashToken("ll_pat_anything");
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("verifyTokenAgainstHash", () => {
+  it("returns true when the token matches the stored hash", () => {
+    const { token, tokenHash } = generatePersonalAccessToken();
+    expect(verifyTokenAgainstHash(token, tokenHash)).toBe(true);
+  });
+
+  it("returns false when the token does not match", () => {
+    const { tokenHash } = generatePersonalAccessToken();
+    expect(verifyTokenAgainstHash("ll_pat_wrongtoken", tokenHash)).toBe(false);
+  });
+
+  it("returns false for malformed (non ll_pat_) tokens", () => {
+    const { tokenHash } = generatePersonalAccessToken();
+    expect(verifyTokenAgainstHash("not-a-pat", tokenHash)).toBe(false);
+  });
+
+  it("does not throw when tokenHash has unexpected length", () => {
+    expect(() => verifyTokenAgainstHash("ll_pat_x", "shorthex")).not.toThrow();
+    expect(verifyTokenAgainstHash("ll_pat_x", "shorthex")).toBe(false);
+  });
+});

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -10,6 +10,7 @@ import {
   ChangePasswordInput,
 } from "@/lib/validations";
 import { Avatar, Badge, Button, Input } from "@/components/ui";
+import { PersonalAccessTokens } from "@/components/settings/PersonalAccessTokens";
 import { User } from "@/types";
 import { formatDate } from "@/lib/utils";
 
@@ -302,6 +303,10 @@ export default function ProfilePage() {
             </Button>
           </div>
         </form>
+      </div>
+
+      <div className="mt-6">
+        <PersonalAccessTokens />
       </div>
     </div>
   );

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,19 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
+import { getCurrentUserOrPATUser } from "@/lib/auth-pat";
 import { prisma } from "@/lib/prisma";
 import { updateProfileSchema } from "@/lib/validations";
 
-export async function GET() {
-  const user = await getCurrentUser();
+export async function GET(request: NextRequest) {
+  // Accepts either a session cookie or a PAT in the Authorization header.
+  const authResult = await getCurrentUserOrPATUser(request);
 
-  if (!user) {
+  if (!authResult) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  return NextResponse.json({ user });
+  return NextResponse.json({ user: authResult.user });
 }
 
 export async function PATCH(request: NextRequest) {
+  // Profile updates remain session-only — we don't want a PAT to be able
+  // to change a user's display name or avatar URL.
   const currentUser = await getCurrentUser();
 
   if (!currentUser) {

--- a/src/app/api/users/me/tokens/[id]/route.ts
+++ b/src/app/api/users/me/tokens/[id]/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Revoke a Personal Access Token.
+ *
+ * Soft delete by setting `revokedAt`. Revoked tokens are kept for audit
+ * but cannot authenticate (see `auth-pat.ts`). Like the create/list
+ * routes, this endpoint requires a session cookie — PAT auth cannot
+ * revoke other PATs.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  // Look up by id AND userId so users can only revoke their own tokens.
+  // Also reject already-revoked tokens with 404 to keep the contract simple.
+  const existing = await prisma.personalAccessToken.findFirst({
+    where: { id, userId: user.id, revokedAt: null },
+    select: { id: true },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: "Token not found" }, { status: 404 });
+  }
+
+  await prisma.personalAccessToken.update({
+    where: { id },
+    data: { revokedAt: new Date() },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/users/me/tokens/route.ts
+++ b/src/app/api/users/me/tokens/route.ts
@@ -1,0 +1,100 @@
+/**
+ * Personal Access Token (PAT) management endpoints.
+ *
+ * SECURITY: These endpoints intentionally use `getCurrentUser()` (session
+ * cookie only). A request authenticated by a PAT must NOT be able to mint
+ * new PATs or list/revoke other PATs. Without this restriction, revocation
+ * is meaningless: a stolen PAT could spawn a fresh one.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import { generatePersonalAccessToken } from "@/lib/pat";
+import { createPATSchema } from "@/lib/validations";
+import {
+  checkAndIncrementCreateRate,
+  PAT_CREATE_LIMIT_PER_HOUR,
+} from "@/lib/pat-rate-limit";
+
+export async function GET() {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const tokens = await prisma.personalAccessToken.findMany({
+    where: { userId: user.id, revokedAt: null },
+    select: {
+      id: true,
+      name: true,
+      prefix: true,
+      scopes: true,
+      lastUsedAt: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json({ personalAccessTokens: tokens });
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const rate = checkAndIncrementCreateRate(user.id);
+  if (!rate.ok) {
+    return NextResponse.json(
+      {
+        error: `Rate limit exceeded — at most ${PAT_CREATE_LIMIT_PER_HOUR} tokens may be created per hour. Try again later.`,
+      },
+      { status: 429 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validation = createPATSchema.safeParse(body);
+  if (!validation.success) {
+    return NextResponse.json(
+      { error: validation.error.errors[0].message },
+      { status: 400 }
+    );
+  }
+
+  const { token, tokenHash, prefix } = generatePersonalAccessToken();
+
+  const created = await prisma.personalAccessToken.create({
+    data: {
+      userId: user.id,
+      name: validation.data.name,
+      tokenHash,
+      prefix,
+      scopes: ["*"],
+    },
+    select: {
+      id: true,
+      name: true,
+      prefix: true,
+      scopes: true,
+      lastUsedAt: true,
+      createdAt: true,
+    },
+  });
+
+  // The raw token is included in the response exactly once. Clients must
+  // surface it immediately and discard it — there is no way to retrieve it
+  // again later.
+  return NextResponse.json(
+    { token, personalAccessToken: created },
+    { status: 201 }
+  );
+}

--- a/src/components/settings/PersonalAccessTokens.tsx
+++ b/src/components/settings/PersonalAccessTokens.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button, Input, Modal } from "@/components/ui";
+import { formatDate, formatRelativeTime } from "@/lib/utils";
+
+/**
+ * UI placement note: rendered inside `/profile`. We chose to extend the
+ * existing profile/settings page rather than introducing a new
+ * `/settings/tokens` route — there is no separate settings hub today and
+ * adding one for a single section would be premature. If the user has more
+ * personal-account settings later, this whole panel can move with no API
+ * changes.
+ */
+
+interface PersonalAccessToken {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: string[];
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+interface CreateResponse {
+  token: string;
+  personalAccessToken: PersonalAccessToken;
+}
+
+export function PersonalAccessTokens() {
+  const [tokens, setTokens] = useState<PersonalAccessToken[] | null>(null);
+  const [loadError, setLoadError] = useState("");
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [createError, setCreateError] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [revealedToken, setRevealedToken] = useState<{
+    token: string;
+    name: string;
+  } | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+
+  const refresh = async () => {
+    try {
+      const res = await fetch("/api/users/me/tokens");
+      if (!res.ok) {
+        setLoadError("Unable to load personal access tokens");
+        return;
+      }
+      const data = await res.json();
+      setTokens(data.personalAccessTokens ?? []);
+      setLoadError("");
+    } catch {
+      setLoadError("Unable to load personal access tokens");
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const openCreate = () => {
+    setCreateName("");
+    setCreateError("");
+    setIsCreateOpen(true);
+  };
+
+  const closeCreate = () => {
+    setIsCreateOpen(false);
+    setCreateName("");
+    setCreateError("");
+  };
+
+  const closeReveal = () => {
+    setRevealedToken(null);
+    setCopyState("idle");
+  };
+
+  const handleCreate = async () => {
+    const trimmed = createName.trim();
+    if (!trimmed) {
+      setCreateError("Name is required");
+      return;
+    }
+    setIsCreating(true);
+    setCreateError("");
+    try {
+      const res = await fetch("/api/users/me/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: trimmed }),
+      });
+      const data = (await res.json()) as CreateResponse | { error: string };
+      if (!res.ok || !("token" in data)) {
+        setCreateError(
+          ("error" in data && data.error) || "Failed to create token"
+        );
+        return;
+      }
+      setIsCreateOpen(false);
+      setCreateName("");
+      setRevealedToken({ token: data.token, name: data.personalAccessToken.name });
+      await refresh();
+    } catch {
+      setCreateError("An error occurred. Please try again.");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleRevoke = async (token: PersonalAccessToken) => {
+    const confirmed = window.confirm(
+      `Revoke "${token.name}"? Any clients using this token will stop working immediately.`
+    );
+    if (!confirmed) return;
+
+    setRevokingId(token.id);
+    try {
+      const res = await fetch(`/api/users/me/tokens/${token.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        setLoadError("Failed to revoke token");
+        return;
+      }
+      await refresh();
+    } finally {
+      setRevokingId(null);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!revealedToken) return;
+    try {
+      await navigator.clipboard.writeText(revealedToken.token);
+      setCopyState("copied");
+      setTimeout(() => setCopyState("idle"), 2000);
+    } catch {
+      // Browsers may block clipboard access — fall back to selecting the text.
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-2xl border border-orange-100 shadow-sm">
+      <div className="border-b border-orange-100 px-8 py-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900">
+            Personal Access Tokens
+          </h2>
+          <p className="text-sm text-gray-500 mt-1">
+            Use tokens to authenticate against the LimeLight API. Treat them
+            like passwords — anyone with a token can act as you.
+          </p>
+        </div>
+        <Button onClick={openCreate}>Create token</Button>
+      </div>
+
+      <div className="p-8">
+        {loadError && (
+          <div className="rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-600 mb-4">
+            {loadError}
+          </div>
+        )}
+
+        {tokens === null ? (
+          <div className="flex items-center justify-center h-32">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-orange-500" />
+          </div>
+        ) : tokens.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-orange-200 bg-orange-50/40 p-8 text-center">
+            <p className="text-sm text-gray-600 mb-4">
+              You haven&apos;t created any personal access tokens yet.
+            </p>
+            <Button onClick={openCreate}>Create your first token</Button>
+          </div>
+        ) : (
+          <ul className="divide-y divide-orange-100">
+            {tokens.map((token) => (
+              <li
+                key={token.id}
+                className="flex items-center justify-between py-4"
+              >
+                <div className="min-w-0 flex-1 pr-4">
+                  <div className="font-semibold text-gray-900">
+                    {token.name}
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
+                    <code className="rounded bg-orange-50 px-2 py-0.5 font-mono text-orange-700">
+                      ll_pat_{token.prefix}…
+                    </code>
+                    <span>Created {formatDate(token.createdAt)}</span>
+                    <span>
+                      {token.lastUsedAt
+                        ? `Last used ${formatRelativeTime(token.lastUsedAt)}`
+                        : "Never used"}
+                    </span>
+                  </div>
+                </div>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  onClick={() => handleRevoke(token)}
+                  isLoading={revokingId === token.id}
+                >
+                  Revoke
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Creation modal */}
+      <Modal isOpen={isCreateOpen} onClose={closeCreate} title="Create token">
+        <div className="space-y-4">
+          {createError && (
+            <div className="rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-600">
+              {createError}
+            </div>
+          )}
+          <Input
+            id="pat-name"
+            label="Token name"
+            placeholder="e.g. ci-deploy"
+            value={createName}
+            onChange={(e) => setCreateName(e.target.value)}
+          />
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={closeCreate}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} isLoading={isCreating}>
+              Create
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* One-time reveal modal */}
+      <Modal
+        isOpen={revealedToken !== null}
+        onClose={closeReveal}
+        title="Token created"
+      >
+        {revealedToken && (
+          <div className="space-y-4">
+            <div className="rounded-xl bg-amber-50 border border-amber-200 p-3 text-sm text-amber-800">
+              Copy now — you won&apos;t see this again. Store it somewhere
+              safe.
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                {revealedToken.name}
+              </label>
+              <div className="flex gap-2">
+                <code className="flex-1 break-all rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 font-mono text-sm text-gray-800">
+                  {revealedToken.token}
+                </code>
+                <Button onClick={handleCopy} variant="outline" size="sm">
+                  {copyState === "copied" ? "Copied!" : "Copy"}
+                </Button>
+              </div>
+            </div>
+            <div className="flex justify-end pt-2">
+              <Button onClick={closeReveal}>Done</Button>
+            </div>
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/src/lib/auth-pat.ts
+++ b/src/lib/auth-pat.ts
@@ -1,0 +1,131 @@
+/**
+ * Authentication helpers that accept either a session cookie or a Personal
+ * Access Token (PAT) via the `Authorization: Bearer <token>` header.
+ *
+ * Existing route handlers can opt in by replacing `getCurrentUser()` with
+ * `getCurrentUserOrPATUser(request)`. PAT-management endpoints should NOT
+ * use this helper — they require a session cookie so a stolen PAT can't
+ * mint or revoke other tokens.
+ */
+
+import type { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import { TOKEN_PREFIX, hashToken, verifyTokenAgainstHash } from "@/lib/pat";
+
+export type AuthenticatedUser = {
+  id: string;
+  email: string;
+  name: string;
+  avatarUrl: string | null;
+  role: "USER" | "ADMIN";
+  createdAt: Date;
+};
+
+export interface AuthResult {
+  user: AuthenticatedUser;
+  /** True when the request was authenticated by a PAT instead of a session cookie. */
+  viaPAT: boolean;
+  /** The PAT id, present only when `viaPAT === true`. */
+  tokenId?: string;
+}
+
+/** Debounce window for `lastUsedAt` updates: at most one DB write per token per minute. */
+const LAST_USED_DEBOUNCE_MS = 60_000;
+
+/**
+ * Per-process in-memory map: tokenId -> last time we wrote `lastUsedAt`.
+ * Best-effort across a single Node process; if the process restarts we may
+ * write twice in one minute, which is fine.
+ */
+const lastUsedWriteCache = new Map<string, number>();
+
+/** Test-only — clear the debounce cache between tests. */
+export function __resetPATLastUsedCacheForTests() {
+  lastUsedWriteCache.clear();
+}
+
+function extractBearerToken(request: NextRequest): string | null {
+  const header = request.headers.get("authorization") ?? request.headers.get("Authorization");
+  if (!header) return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  const candidate = match[1].trim();
+  if (!candidate.startsWith(TOKEN_PREFIX)) return null;
+  return candidate;
+}
+
+async function authenticateViaPAT(token: string): Promise<AuthResult | null> {
+  const tokenHash = hashToken(token);
+
+  const record = await prisma.personalAccessToken.findUnique({
+    where: { tokenHash },
+    include: {
+      user: {
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          avatarUrl: true,
+          role: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+
+  if (!record) return null;
+  if (record.revokedAt) return null;
+  // Belt-and-suspenders: verify with a constant-time compare even though we
+  // matched on the hash. Guards against a future where the lookup is changed.
+  if (!verifyTokenAgainstHash(token, record.tokenHash)) return null;
+
+  // Debounced lastUsedAt update — at most once per minute per token.
+  const now = Date.now();
+  const lastWrite = lastUsedWriteCache.get(record.id) ?? 0;
+  if (now - lastWrite >= LAST_USED_DEBOUNCE_MS) {
+    lastUsedWriteCache.set(record.id, now);
+    // Fire-and-forget; we don't want to fail the request if this update fails.
+    try {
+      const updateResult = prisma.personalAccessToken.update({
+        where: { id: record.id },
+        data: { lastUsedAt: new Date(now) },
+      });
+      if (
+        updateResult &&
+        typeof (updateResult as Promise<unknown>).catch === "function"
+      ) {
+        (updateResult as Promise<unknown>).catch(() => {
+          lastUsedWriteCache.delete(record.id);
+        });
+      }
+    } catch {
+      lastUsedWriteCache.delete(record.id);
+    }
+  }
+
+  return {
+    user: record.user as AuthenticatedUser,
+    viaPAT: true,
+    tokenId: record.id,
+  };
+}
+
+/**
+ * Resolve the current user from either a session cookie OR a PAT in the
+ * `Authorization: Bearer ...` header. Session cookie takes precedence —
+ * a logged-in user with a PAT in the header still authenticates as a
+ * session user (so PAT-mgmt endpoints that check `viaPAT` see false).
+ */
+export async function getCurrentUserOrPATUser(
+  request: NextRequest
+): Promise<AuthResult | null> {
+  const sessionUser = await getCurrentUser();
+  if (sessionUser) {
+    return { user: sessionUser as AuthenticatedUser, viaPAT: false };
+  }
+
+  const bearer = extractBearerToken(request);
+  if (!bearer) return null;
+  return authenticateViaPAT(bearer);
+}

--- a/src/lib/pat-rate-limit.ts
+++ b/src/lib/pat-rate-limit.ts
@@ -1,0 +1,43 @@
+/**
+ * Simple in-memory rolling-window rate limiter for PAT creation.
+ *
+ * Limit: 10 creations per rolling 1-hour window per user. This is per-process
+ * and resets on restart — fine for v1. A future iteration can move this to
+ * Redis or a database counter.
+ *
+ * Why limit creation? An authenticated attacker could otherwise mint
+ * thousands of tokens, e.g. as a denial-of-service vector or to make
+ * revocation infeasible.
+ */
+
+export const PAT_CREATE_LIMIT_PER_HOUR = 10;
+const WINDOW_MS = 60 * 60 * 1000;
+
+const buckets = new Map<string, number[]>();
+
+export interface RateCheckResult {
+  ok: boolean;
+  remaining: number;
+}
+
+export function checkAndIncrementCreateRate(userId: string): RateCheckResult {
+  const now = Date.now();
+  const cutoff = now - WINDOW_MS;
+  const existing = buckets.get(userId) ?? [];
+  // Drop entries outside the window
+  const fresh = existing.filter((t) => t > cutoff);
+
+  if (fresh.length >= PAT_CREATE_LIMIT_PER_HOUR) {
+    buckets.set(userId, fresh);
+    return { ok: false, remaining: 0 };
+  }
+
+  fresh.push(now);
+  buckets.set(userId, fresh);
+  return { ok: true, remaining: PAT_CREATE_LIMIT_PER_HOUR - fresh.length };
+}
+
+/** Test-only reset hook. */
+export function __resetRateLimiterForTests() {
+  buckets.clear();
+}

--- a/src/lib/pat.ts
+++ b/src/lib/pat.ts
@@ -1,0 +1,74 @@
+/**
+ * Personal Access Token (PAT) helpers.
+ *
+ * Tokens are 256-bit random secrets, base64url-encoded, prefixed with
+ * `ll_pat_` for log identification. We store only a sha256 hash of the
+ * token. Why sha256 instead of bcrypt?
+ *
+ *   - bcrypt is intentionally slow and is appropriate for low-entropy
+ *     human-chosen passwords, where attackers would otherwise grind
+ *     through dictionaries.
+ *   - PATs are 256 bits of cryptographically-secure randomness — they are
+ *     not guessable. The threat model is "attacker has the database hash
+ *     and wants to recover the token". With 2^256 possibilities, a fast
+ *     hash is no easier to attack than a slow one.
+ *   - Authentication needs to be fast (every API request) — bcrypt would
+ *     make every PAT-authenticated request take ~100ms.
+ *
+ * Verification uses `crypto.timingSafeEqual` on equal-length buffers to
+ * prevent timing-based hash recovery.
+ */
+
+import { createHash, randomBytes, timingSafeEqual } from "crypto";
+
+export const TOKEN_PREFIX = "ll_pat_";
+/** Number of chars after `ll_pat_` we expose publicly for token identification. */
+export const PUBLIC_PREFIX_LENGTH = 8;
+/** Random bytes for the secret part of the token. */
+const SECRET_BYTES = 32;
+
+export interface GeneratedToken {
+  /** The raw token, e.g. `ll_pat_abc...`. Show to the user once and never persist. */
+  token: string;
+  /** sha256 hash of the raw token, hex-encoded. Persist this. */
+  tokenHash: string;
+  /** First {@link PUBLIC_PREFIX_LENGTH} chars after the `ll_pat_` prefix. Persist for display. */
+  prefix: string;
+}
+
+/**
+ * Generate a new PAT. The raw token is returned exactly once — callers must
+ * surface it to the user immediately and discard it.
+ */
+export function generatePersonalAccessToken(): GeneratedToken {
+  const secret = randomBytes(SECRET_BYTES).toString("base64url");
+  const token = `${TOKEN_PREFIX}${secret}`;
+  const tokenHash = hashToken(token);
+  const prefix = secret.slice(0, PUBLIC_PREFIX_LENGTH);
+  return { token, tokenHash, prefix };
+}
+
+/**
+ * Compute the sha256 hash of a raw token, hex-encoded.
+ */
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Verify a raw token against a stored sha256 hex hash using a constant-time
+ * comparison. Returns false rather than throwing on malformed inputs.
+ */
+export function verifyTokenAgainstHash(token: string, storedHash: string): boolean {
+  if (!token.startsWith(TOKEN_PREFIX)) return false;
+  const computed = hashToken(token);
+  if (computed.length !== storedHash.length) return false;
+  try {
+    const a = Buffer.from(computed, "hex");
+    const b = Buffer.from(storedHash, "hex");
+    if (a.length !== b.length || a.length === 0) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -103,6 +103,16 @@ export const changePasswordSchema = z
     path: ["newPassword"],
   });
 
+// Personal Access Token validations
+export const createPATSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(100, "Name too long")
+    .trim(),
+});
+export type CreatePATInput = z.infer<typeof createPATSchema>;
+
 // Vulnerability validations
 const VULN_SEVERITY = ["LOW", "MEDIUM", "HIGH", "CRITICAL"] as const;
 const VULN_STATUS = [


### PR DESCRIPTION
## Summary

Adds a complete Personal Access Token (PAT) mechanism so users can
authenticate against the LimeLight API programmatically. v1 ships
full-access tokens; the data model and UI already accommodate scoped
permissions in a follow-up.

- **DB**: new `PersonalAccessToken` model with `tokenHash`, `prefix`,
  `scopes` (default `["*"]`), `lastUsedAt`, `revokedAt`, indexes on
  `userId` and `tokenHash`, `User` back-relation
- **Library**: `src/lib/pat.ts` (token generation, sha256 hash,
  constant-time verify), `src/lib/auth-pat.ts`
  (`getCurrentUserOrPATUser` accepting either session cookie or
  `Authorization: Bearer ll_pat_…`), `src/lib/pat-rate-limit.ts`
  (10 creates/hour/user)
- **API**: `GET`/`POST /api/users/me/tokens`,
  `DELETE /api/users/me/tokens/[id]`, all session-cookie-only.
  `GET /api/auth/me` now also accepts PATs.
- **UI**: `Personal Access Tokens` panel inside `/profile` — list with
  prefix + last-used, empty state, create modal, one-time reveal with
  copy button and "Copy now — you won't see this again" warning,
  revoke with `window.confirm` dialog. Matches the orange/`rounded-2xl`
  style.
- **README**: documents token format and the `Authorization: Bearer`
  flow, plus the security rationale below.

Closes #3.

## Test plan

All gates run with the test DATABASE_URL/JWT_SECRET from CLAUDE.md.

- [x] `npm test` — **249 / 249 passing**, **24 suites**
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no errors (only pre-existing warnings in
  unrelated files)
- [x] `npm run build` — succeeds; new routes
  `/api/users/me/tokens` and `/api/users/me/tokens/[id]` show up

New tests (TDD red → green):

- `src/__tests__/lib/pat.test.ts` — token format, hash determinism,
  constant-time verify (12 tests)
- `src/__tests__/lib/auth-pat.test.ts` — session fallback, Bearer
  acceptance, revoked rejection, malformed rejection, debounced
  `lastUsedAt` (8 tests)
- `src/__tests__/lib/pat-rate-limit.test.ts` — limit enforcement
  and per-user isolation (3 tests)
- `src/__tests__/api/tokens.test.ts` — create returns raw token
  once and persists only hash; list never exposes raw/hash; revoke
  is a soft-delete; rate limit returns 429 (10 tests)
- `src/__tests__/api/tokens-pat-block.test.ts` — PAT auth cannot
  hit any PAT-mgmt endpoint (3 tests)
- `src/__tests__/api/auth-me-pat.test.ts` — `/api/auth/me` works
  with valid PAT, rejects revoked, rejects malformed, still works
  with session (4 tests)
- `src/__tests__/components/PersonalAccessTokens.test.tsx` — empty
  state, list rendering, create flow shows token once with warning,
  revoke triggers DELETE (4 tests)

## Security notes

- **sha256, not bcrypt**: PATs are 256 bits of cryptographically
  secure randomness. bcrypt's slowness is appropriate for low-entropy
  human passwords; for PATs there is no dictionary attack to slow
  down. Using a fast hash also means PAT-authenticated requests
  don't pay ~100 ms per call.
- **Constant-time compare**: hash verification uses
  `crypto.timingSafeEqual` on equal-length buffers, so an attacker
  who has read access to the hash cannot use timing differences to
  recover it.
- **Token format**: `ll_pat_<32 random base64url bytes>`. The
  `ll_pat_` prefix is identifiable in logs. Only the sha256 hash and
  the first 8 chars (the `prefix` column) are persisted; the raw
  token is shown to the user exactly once.
- **PAT-mgmt endpoints are session-only**: a stolen PAT cannot mint
  or revoke other PATs. Without this, revocation would be
  meaningless.
- **Profile updates** (`PATCH /api/auth/me`) also kept
  session-only so a PAT cannot change a user's display name or
  avatar.
- **Rate limit**: 10 token creations per rolling hour per user
  (in-memory token bucket; per-process for v1).
- **Last-used updates** are debounced to once per minute per token
  to keep the auth path fast.

## Follow-ups

- Scoped permissions (`scopes` field already exists, defaulted to
  `["*"]`)
- Token expiration / TTL
- Move the rate-limiter from in-memory to a shared store (Redis or
  DB counter) once we run multiple instances
- Apply `getCurrentUserOrPATUser` to additional protected API routes
  beyond `/api/auth/me` if/when external integrations need them