### PR TITLE
feat: add task filtering on the project board

### DIFF
--- a/src/__tests__/api/tasks-filtering.test.ts
+++ b/src/__tests__/api/tasks-filtering.test.ts
@@ -1,0 +1,198 @@
+/**
+ * @jest-environment node
+ *
+ * Tests the project-tasks list endpoint with filter query params. Prisma and
+ * auth are mocked so these run without a database. Verifies the where-clause
+ * the route hands to Prisma for each filter category and combinations of them.
+ */
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    projectMember: { findFirst: jest.fn() },
+    task: { findMany: jest.fn() },
+  },
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import { GET } from "@/app/api/projects/[id]/tasks/route";
+
+const mockedAuth = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
+const mockedPrisma = prisma as unknown as {
+  projectMember: { findFirst: jest.Mock };
+  task: { findMany: jest.Mock };
+};
+
+const me = {
+  id: "user-me",
+  email: "me@test.com",
+  name: "Me",
+  avatarUrl: null,
+  role: "USER" as const,
+  createdAt: new Date("2024-01-01"),
+};
+
+function makeRequest(url: string) {
+  return new NextRequest(url);
+}
+
+const paramsFor = (id: string) => Promise.resolve({ id });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedPrisma.task.findMany.mockResolvedValue([]);
+});
+
+async function callGetWithSearch(query: string) {
+  return GET(
+    makeRequest(`http://localhost/api/projects/p1/tasks?${query}`),
+    { params: paramsFor("p1") } as never
+  );
+}
+
+describe("GET /api/projects/[id]/tasks (filtering)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const res = await callGetWithSearch("");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is not a project member", async () => {
+    mockedAuth.mockResolvedValue(me);
+    mockedPrisma.projectMember.findFirst.mockResolvedValue(null);
+    const res = await callGetWithSearch("priority=HIGH");
+    expect(res.status).toBe(403);
+  });
+
+  describe("when authorised", () => {
+    beforeEach(() => {
+      mockedAuth.mockResolvedValue(me);
+      mockedPrisma.projectMember.findFirst.mockResolvedValue({
+        id: "m1",
+        role: "MEMBER",
+      });
+    });
+
+    it("scopes by projectId only when no filters are passed", async () => {
+      const res = await callGetWithSearch("");
+      expect(res.status).toBe(200);
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where).toEqual({ projectId: "p1" });
+    });
+
+    it("filters by priority", async () => {
+      await callGetWithSearch("priority=HIGH,URGENT");
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where).toMatchObject({
+        projectId: "p1",
+        priority: { in: ["HIGH", "URGENT"] },
+      });
+    });
+
+    it("ignores invalid priorities silently", async () => {
+      await callGetWithSearch("priority=BANANA");
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where).toEqual({ projectId: "p1" });
+    });
+
+    it("filters by status ids", async () => {
+      await callGetWithSearch("status=s-todo,s-done");
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where).toMatchObject({
+        projectId: "p1",
+        statusId: { in: ["s-todo", "s-done"] },
+      });
+    });
+
+    it("filters by assignee ids", async () => {
+      await callGetWithSearch("assignee=u1,u2");
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where).toMatchObject({
+        projectId: "p1",
+        assigneeId: { in: ["u1", "u2"] },
+      });
+    });
+
+    it("expands the 'me' shortcut to the current user id", async () => {
+      await callGetWithSearch("assignee=me");
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where).toMatchObject({
+        projectId: "p1",
+        assigneeId: me.id,
+      });
+    });
+
+    it("expands the 'unassigned' shortcut to a null assignee", async () => {
+      await callGetWithSearch("assignee=unassigned");
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where).toMatchObject({
+        projectId: "p1",
+        assigneeId: null,
+      });
+    });
+
+    it("ORs unassigned with explicit ids when both are present", async () => {
+      await callGetWithSearch("assignee=u1,unassigned");
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where).toMatchObject({
+        projectId: "p1",
+        OR: [{ assigneeId: { in: ["u1"] } }, { assigneeId: null }],
+      });
+    });
+
+    it("filters by free-text search on title and description", async () => {
+      await callGetWithSearch("search=login%20bug");
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where).toMatchObject({
+        projectId: "p1",
+        OR: [
+          { title: { contains: "login bug", mode: "insensitive" } },
+          { description: { contains: "login bug", mode: "insensitive" } },
+        ],
+      });
+    });
+
+    it("ignores whitespace-only search", async () => {
+      await callGetWithSearch("search=%20%20%20");
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where).toEqual({ projectId: "p1" });
+    });
+
+    it("combines priority + status + assignee + search", async () => {
+      await callGetWithSearch(
+        "priority=HIGH&status=s1&assignee=me&search=auth"
+      );
+      const call = mockedPrisma.task.findMany.mock.calls[0][0];
+      expect(call.where.projectId).toBe("p1");
+      expect(call.where.priority).toEqual({ in: ["HIGH"] });
+      expect(call.where.statusId).toEqual({ in: ["s1"] });
+      expect(call.where.assigneeId).toBe(me.id);
+      // Single assignee branch leaves the OR slot for search.
+      expect(call.where.OR).toEqual([
+        { title: { contains: "auth", mode: "insensitive" } },
+        { description: { contains: "auth", mode: "insensitive" } },
+      ]);
+    });
+
+    it("returns the filtered task list in the response body", async () => {
+      const tasks = [{ id: "t1", title: "Hello" }];
+      mockedPrisma.task.findMany.mockResolvedValue(tasks);
+      const res = await callGetWithSearch("priority=HIGH");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.tasks).toEqual(tasks);
+    });
+
+    it("returns an empty array when no tasks match", async () => {
+      mockedPrisma.task.findMany.mockResolvedValue([]);
+      const res = await callGetWithSearch("priority=URGENT");
+      const body = await res.json();
+      expect(body.tasks).toEqual([]);
+    });
+  });
+});

--- a/src/__tests__/components/BoardWithFilters.test.tsx
+++ b/src/__tests__/components/BoardWithFilters.test.tsx
@@ -1,0 +1,307 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BoardWithFilters } from "@/components/board/board-with-filters";
+import { ProjectWithMembers, Status, Task, User } from "@/types";
+
+// Avoid pulling in dnd-kit's heavy machinery — render a simple stub Board so we
+// can assert filter wiring (which tasks reach the board) without DnD overhead.
+jest.mock("@/components/board/board", () => ({
+  Board: ({
+    initialTasks,
+    filtersActive,
+  }: {
+    initialTasks: Task[];
+    filtersActive: boolean;
+  }) => (
+    <div>
+      <div data-testid="board-filters-active">{String(filtersActive)}</div>
+      <ul data-testid="board-tasks">
+        {initialTasks.map((t) => (
+          <li key={t.id} data-testid={`task-${t.id}`}>
+            {t.title}
+          </li>
+        ))}
+      </ul>
+    </div>
+  ),
+}));
+
+const mockReplace = jest.fn();
+const mockUseSearchParams = jest.fn(() => new URLSearchParams());
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: mockReplace,
+    refresh: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+  useSearchParams: () => mockUseSearchParams(),
+  usePathname: () => "/projects/p1",
+  useParams: () => ({ id: "p1" }),
+}));
+
+const me: User = {
+  id: "user-me",
+  email: "me@test.com",
+  name: "Me",
+  avatarUrl: null,
+  role: "USER",
+  createdAt: new Date(),
+};
+
+const alice: User = { ...me, id: "user-alice", name: "Alice" };
+
+const statuses: Status[] = [
+  { id: "s-todo", name: "To Do", order: 0, projectId: "p1" },
+  { id: "s-doing", name: "In Progress", order: 1, projectId: "p1" },
+];
+
+const project: ProjectWithMembers = {
+  id: "p1",
+  name: "Project",
+  key: "PROJ",
+  description: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  members: [
+    {
+      id: "pm1",
+      userId: me.id,
+      projectId: "p1",
+      role: "MEMBER",
+      createdAt: new Date(),
+      user: me,
+    },
+    {
+      id: "pm2",
+      userId: alice.id,
+      projectId: "p1",
+      role: "MEMBER",
+      createdAt: new Date(),
+      user: alice,
+    },
+  ],
+  statuses,
+};
+
+function task(overrides: Partial<Task>): Task {
+  return {
+    id: "t1",
+    title: "Default task",
+    description: null,
+    key: "PROJ-1",
+    priority: "MEDIUM",
+    order: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    projectId: "p1",
+    statusId: "s-todo",
+    assigneeId: null,
+    creatorId: me.id,
+    ...overrides,
+  };
+}
+
+const initialTasks = [
+  task({ id: "t1", title: "First", priority: "HIGH" }),
+  task({ id: "t2", title: "Second", priority: "LOW" }),
+];
+
+beforeEach(() => {
+  mockReplace.mockReset();
+  mockUseSearchParams.mockReturnValue(new URLSearchParams());
+  (global.fetch as jest.Mock).mockReset();
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: async () => ({ tasks: [] }),
+  });
+});
+
+describe("BoardWithFilters", () => {
+  it("renders the filter bar and forwards initial tasks to the board", () => {
+    render(
+      <BoardWithFilters
+        project={project}
+        initialTasks={initialTasks}
+        members={[me, alice]}
+        currentUser={me}
+      />
+    );
+
+    expect(screen.getByPlaceholderText(/search tasks/i)).toBeInTheDocument();
+    expect(screen.getByTestId("task-t1")).toBeInTheDocument();
+    expect(screen.getByTestId("task-t2")).toBeInTheDocument();
+    expect(screen.getByTestId("board-filters-active")).toHaveTextContent(
+      "false"
+    );
+  });
+
+  it("updates the URL when a filter is selected", async () => {
+    const user = userEvent.setup();
+    render(
+      <BoardWithFilters
+        project={project}
+        initialTasks={initialTasks}
+        members={[me, alice]}
+        currentUser={me}
+      />
+    );
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: [task({ id: "t1", title: "First" })] }),
+    });
+
+    await user.click(screen.getByRole("button", { name: /^priority$/i }));
+    await user.click(screen.getByRole("button", { name: /^high$/i }));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalled();
+    });
+    const lastUrl = mockReplace.mock.calls.at(-1)![0];
+    expect(lastUrl).toContain("priority=HIGH");
+    // Allow the triggered fetch to settle before the test exits.
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  it("fetches filtered tasks from the API and replaces the list", async () => {
+    const user = userEvent.setup();
+    render(
+      <BoardWithFilters
+        project={project}
+        initialTasks={initialTasks}
+        members={[me, alice]}
+        currentUser={me}
+      />
+    );
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: [task({ id: "t1", title: "Filtered" })] }),
+    });
+
+    await user.click(screen.getByRole("button", { name: /^priority$/i }));
+    await user.click(screen.getByRole("button", { name: /^high$/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    const url = (global.fetch as jest.Mock).mock.calls.at(-1)![0] as string;
+    expect(url).toContain("/api/projects/p1/tasks");
+    expect(url).toContain("priority=HIGH");
+
+    await waitFor(() => {
+      expect(screen.getByText("Filtered")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Second")).not.toBeInTheDocument();
+    expect(screen.getByTestId("board-filters-active")).toHaveTextContent(
+      "true"
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("tasks-loading")).not.toBeInTheDocument();
+    });
+  });
+
+  it("hydrates initial filter state from the URL", async () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("priority=HIGH"));
+    render(
+      <BoardWithFilters
+        project={project}
+        initialTasks={initialTasks}
+        members={[me, alice]}
+        currentUser={me}
+      />
+    );
+    expect(screen.getByTestId("active-filter-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("filter-chip-priority-HIGH")).toBeInTheDocument();
+    // Wait for the mount-triggered fetch (active filter on mount) to settle so
+    // we don't leak act() warnings into other tests.
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  it("debounces search input before firing a request", async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(
+      <BoardWithFilters
+        project={project}
+        initialTasks={initialTasks}
+        members={[me, alice]}
+        currentUser={me}
+      />
+    );
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: [] }),
+    });
+
+    const input = screen.getByPlaceholderText(/search tasks/i);
+    await user.type(input, "auth");
+
+    // Less than 300ms — no fetch yet.
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+    // After the debounce, exactly one fetch with the search param.
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    const url = (global.fetch as jest.Mock).mock.calls.at(-1)![0] as string;
+    expect(url).toMatch(/search=auth/);
+
+    // Drain any remaining microtasks before switching timers.
+    await act(async () => {
+      jest.runAllTimers();
+      await Promise.resolve();
+    });
+    jest.useRealTimers();
+    await waitFor(() => {
+      expect(screen.queryByTestId("tasks-loading")).not.toBeInTheDocument();
+    });
+  });
+
+  it("clears all filters and refetches an unfiltered list", async () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("priority=HIGH"));
+    const user = userEvent.setup();
+    render(
+      <BoardWithFilters
+        project={project}
+        initialTasks={initialTasks}
+        members={[me, alice]}
+        currentUser={me}
+      />
+    );
+
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ tasks: initialTasks }),
+    });
+
+    await user.click(screen.getByRole("button", { name: /clear all/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    const url = (global.fetch as jest.Mock).mock.calls.at(-1)![0] as string;
+    expect(url).not.toContain("priority=");
+    expect(screen.getByTestId("board-filters-active")).toHaveTextContent(
+      "false"
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("tasks-loading")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/components/Column.test.tsx
+++ b/src/__tests__/components/Column.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { DndContext } from "@dnd-kit/core";
+import { Column } from "@/components/board/column";
+import { Status } from "@/types";
+
+const status: Status = {
+  id: "s1",
+  name: "To Do",
+  order: 0,
+  projectId: "p1",
+};
+
+function renderColumn(
+  props: Partial<React.ComponentProps<typeof Column>> = {}
+) {
+  return render(
+    <DndContext>
+      <Column
+        status={status}
+        tasks={[]}
+        onTaskClick={() => {}}
+        filtersActive={false}
+        {...props}
+      />
+    </DndContext>
+  );
+}
+
+describe("Column", () => {
+  it("shows the default empty drop zone when no filters are active", () => {
+    renderColumn();
+    expect(screen.getByText(/drop tasks here/i)).toBeInTheDocument();
+  });
+
+  it("shows a 'no tasks match your filters' empty state when filters are active", () => {
+    renderColumn({ filtersActive: true });
+    expect(
+      screen.getByText(/no tasks match your filters/i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the empty state when tasks are present", () => {
+    renderColumn({
+      filtersActive: true,
+      tasks: [
+        {
+          id: "t1",
+          title: "T",
+          description: null,
+          key: "K-1",
+          priority: "MEDIUM",
+          order: 0,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          projectId: "p1",
+          statusId: "s1",
+          assigneeId: null,
+          creatorId: "u1",
+        },
+      ],
+    });
+    expect(
+      screen.queryByText(/no tasks match your filters/i)
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/drop tasks here/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/TaskFilterBar.test.tsx
+++ b/src/__tests__/components/TaskFilterBar.test.tsx
@@ -1,0 +1,248 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TaskFilterBar } from "@/components/board/task-filter-bar";
+import { Status, User } from "@/types";
+
+const me: User = {
+  id: "user-me",
+  email: "me@test.com",
+  name: "Me",
+  avatarUrl: null,
+  role: "USER",
+  createdAt: new Date("2024-01-01"),
+};
+
+const alice: User = {
+  ...me,
+  id: "user-alice",
+  email: "alice@test.com",
+  name: "Alice",
+};
+
+const bob: User = {
+  ...me,
+  id: "user-bob",
+  email: "bob@test.com",
+  name: "Bob",
+};
+
+const statuses: Status[] = [
+  { id: "s-todo", name: "To Do", order: 0, projectId: "p1" },
+  { id: "s-doing", name: "In Progress", order: 1, projectId: "p1" },
+  { id: "s-done", name: "Done", order: 2, projectId: "p1" },
+];
+
+const baseProps = {
+  members: [me, alice, bob],
+  currentUser: me,
+  statuses,
+  filters: {
+    assigneeIds: [] as string[],
+    includeMe: false,
+    includeUnassigned: false,
+    priorities: [] as string[],
+    statusIds: [] as string[],
+    search: "",
+  },
+  onFiltersChange: jest.fn(),
+};
+
+describe("TaskFilterBar", () => {
+  beforeEach(() => {
+    baseProps.onFiltersChange.mockReset();
+  });
+
+  it("renders a search input with a placeholder", () => {
+    render(<TaskFilterBar {...baseProps} />);
+    const input = screen.getByPlaceholderText(/search tasks/i);
+    expect(input).toBeInTheDocument();
+  });
+
+  it("debounces search input updates", async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onFiltersChange = jest.fn();
+    render(
+      <TaskFilterBar
+        {...baseProps}
+        onFiltersChange={onFiltersChange}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/search tasks/i);
+    await user.type(input, "abc");
+
+    // Less than 300ms — no callback yet.
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(onFiltersChange).not.toHaveBeenCalled();
+
+    // After 300ms, the callback fires once with the final value.
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+    expect(onFiltersChange).toHaveBeenCalled();
+    const last = onFiltersChange.mock.calls.at(-1)![0];
+    expect(last.search).toBe("abc");
+
+    jest.useRealTimers();
+  });
+
+  it("focuses the search input when '/' is pressed", async () => {
+    const user = userEvent.setup();
+    render(<TaskFilterBar {...baseProps} />);
+    // Move focus away from any default focus
+    document.body.focus();
+    await user.keyboard("/");
+    const input = screen.getByPlaceholderText(/search tasks/i);
+    expect(input).toHaveFocus();
+  });
+
+  it("does not steal focus from another input when '/' is typed there", async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <input data-testid="other" />
+        <TaskFilterBar {...baseProps} />
+      </div>
+    );
+    const other = screen.getByTestId("other");
+    other.focus();
+    await user.keyboard("/");
+    expect(other).toHaveFocus();
+  });
+
+  it("clears the search input via the clear button", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = jest.fn();
+    render(
+      <TaskFilterBar
+        {...baseProps}
+        filters={{ ...baseProps.filters, search: "auth" }}
+        onFiltersChange={onFiltersChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /clear search/i }));
+    const last = onFiltersChange.mock.calls.at(-1)![0];
+    expect(last.search).toBe("");
+  });
+
+  it("opens the priority popover and toggles a priority", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = jest.fn();
+    render(
+      <TaskFilterBar
+        {...baseProps}
+        onFiltersChange={onFiltersChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^priority$/i }));
+    await user.click(screen.getByRole("button", { name: /^high$/i }));
+
+    const last = onFiltersChange.mock.calls.at(-1)![0];
+    expect(last.priorities).toEqual(["HIGH"]);
+  });
+
+  it("opens the status popover and toggles status ids", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = jest.fn();
+    render(
+      <TaskFilterBar {...baseProps} onFiltersChange={onFiltersChange} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^status$/i }));
+    await user.click(screen.getByRole("button", { name: /^to do$/i }));
+
+    const last = onFiltersChange.mock.calls.at(-1)![0];
+    expect(last.statusIds).toEqual(["s-todo"]);
+  });
+
+  it("opens the assignee popover and toggles members + me + unassigned", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = jest.fn();
+    render(
+      <TaskFilterBar {...baseProps} onFiltersChange={onFiltersChange} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^assignee$/i }));
+    await user.click(screen.getByRole("button", { name: /^me$/i }));
+    expect(onFiltersChange.mock.calls.at(-1)![0].includeMe).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: /^unassigned$/i }));
+    expect(onFiltersChange.mock.calls.at(-1)![0].includeUnassigned).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: /alice/i }));
+    expect(onFiltersChange.mock.calls.at(-1)![0].assigneeIds).toContain(
+      "user-alice"
+    );
+  });
+
+  it("shows the active filter count on the filter button", () => {
+    render(
+      <TaskFilterBar
+        {...baseProps}
+        filters={{
+          ...baseProps.filters,
+          priorities: ["HIGH"],
+          statusIds: ["s-todo"],
+          includeMe: true,
+          search: "auth",
+        }}
+      />
+    );
+    // 1 priority + 1 status + 1 assignee shortcut + 1 search = 4
+    expect(screen.getByTestId("active-filter-count")).toHaveTextContent("4");
+  });
+
+  it("renders a clear-all button only when filters are active", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = jest.fn();
+    const { rerender } = render(
+      <TaskFilterBar {...baseProps} onFiltersChange={onFiltersChange} />
+    );
+    expect(
+      screen.queryByRole("button", { name: /clear all/i })
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <TaskFilterBar
+        {...baseProps}
+        filters={{ ...baseProps.filters, priorities: ["HIGH"] }}
+        onFiltersChange={onFiltersChange}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /clear all/i }));
+    const last = onFiltersChange.mock.calls.at(-1)![0];
+    expect(last.priorities).toEqual([]);
+    expect(last.search).toBe("");
+  });
+
+  it("renders chips for each active filter", () => {
+    render(
+      <TaskFilterBar
+        {...baseProps}
+        filters={{
+          ...baseProps.filters,
+          priorities: ["HIGH"],
+          statusIds: ["s-todo"],
+          includeMe: true,
+          includeUnassigned: true,
+          assigneeIds: ["user-alice"],
+        }}
+      />
+    );
+    expect(screen.getByTestId("filter-chip-priority-HIGH")).toBeInTheDocument();
+    expect(screen.getByTestId("filter-chip-status-s-todo")).toBeInTheDocument();
+    expect(screen.getByTestId("filter-chip-assignee-me")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("filter-chip-assignee-unassigned")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("filter-chip-assignee-user-alice")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/lib/task-filters.test.ts
+++ b/src/__tests__/lib/task-filters.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for task-filter parsing and Prisma where-clause composition.
+ *
+ * The filter API takes a raw URLSearchParams from the request, the current
+ * user id (for the "me" assignee shortcut), and returns:
+ *   1. a parsed, normalised filter object, and
+ *   2. a Prisma `where` fragment that can be merged with the projectId scope.
+ *
+ * Behaviour:
+ *   - Filters combine with AND across categories, OR within a category.
+ *   - Invalid values are silently ignored.
+ *   - Empty / missing params produce no filter constraints (other than scope).
+ *   - "me" expands to the current user id; "unassigned" matches assigneeId === null.
+ */
+import {
+  parseTaskFilters,
+  buildTaskWhere,
+} from "@/lib/task-filters";
+
+describe("parseTaskFilters", () => {
+  it("returns empty filters when no params are provided", () => {
+    const filters = parseTaskFilters(new URLSearchParams(), "user-1");
+    expect(filters).toEqual({
+      assigneeIds: [],
+      includeUnassigned: false,
+      includeMe: false,
+      priorities: [],
+      statusIds: [],
+      search: "",
+      meId: "user-1",
+    });
+  });
+
+  it("parses comma-separated assignee ids", () => {
+    const params = new URLSearchParams("assignee=u1,u2,u3");
+    const filters = parseTaskFilters(params, "me-id");
+    expect(filters.assigneeIds).toEqual(["u1", "u2", "u3"]);
+  });
+
+  it("recognises 'unassigned' shortcut in the assignee param", () => {
+    const params = new URLSearchParams("assignee=unassigned,u1");
+    const filters = parseTaskFilters(params, "me-id");
+    expect(filters.includeUnassigned).toBe(true);
+    expect(filters.assigneeIds).toEqual(["u1"]);
+  });
+
+  it("recognises 'me' shortcut in the assignee param", () => {
+    const params = new URLSearchParams("assignee=me,u2");
+    const filters = parseTaskFilters(params, "me-id");
+    expect(filters.includeMe).toBe(true);
+    expect(filters.assigneeIds).toEqual(["u2"]);
+  });
+
+  it("parses priority and uppercases values", () => {
+    const params = new URLSearchParams("priority=low,High");
+    const filters = parseTaskFilters(params, "me-id");
+    expect(filters.priorities).toEqual(["LOW", "HIGH"]);
+  });
+
+  it("ignores invalid priority values", () => {
+    const params = new URLSearchParams("priority=BANANA,LOW,;drop");
+    const filters = parseTaskFilters(params, "me-id");
+    expect(filters.priorities).toEqual(["LOW"]);
+  });
+
+  it("parses status ids verbatim", () => {
+    const params = new URLSearchParams("status=todo-id,done-id");
+    const filters = parseTaskFilters(params, "me-id");
+    expect(filters.statusIds).toEqual(["todo-id", "done-id"]);
+  });
+
+  it("trims and lowercases the search query but preserves user input casing for matching", () => {
+    const params = new URLSearchParams("search=  fix bug  ");
+    const filters = parseTaskFilters(params, "me-id");
+    expect(filters.search).toBe("fix bug");
+  });
+
+  it("returns empty search for whitespace-only input", () => {
+    const params = new URLSearchParams("search=   ");
+    const filters = parseTaskFilters(params, "me-id");
+    expect(filters.search).toBe("");
+  });
+});
+
+describe("buildTaskWhere", () => {
+  const projectId = "project-1";
+  const meId = "user-me";
+
+  it("returns scope-only where when filters are empty", () => {
+    const where = buildTaskWhere(projectId, parseTaskFilters(new URLSearchParams(), meId));
+    expect(where).toEqual({ projectId });
+  });
+
+  it("filters by priorities (OR within category)", () => {
+    const filters = parseTaskFilters(new URLSearchParams("priority=HIGH,URGENT"), meId);
+    const where = buildTaskWhere(projectId, filters);
+    expect(where).toEqual({
+      projectId,
+      priority: { in: ["HIGH", "URGENT"] },
+    });
+  });
+
+  it("filters by status ids (OR within category)", () => {
+    const filters = parseTaskFilters(new URLSearchParams("status=s1,s2"), meId);
+    const where = buildTaskWhere(projectId, filters);
+    expect(where).toEqual({
+      projectId,
+      statusId: { in: ["s1", "s2"] },
+    });
+  });
+
+  it("filters by assignee ids", () => {
+    const filters = parseTaskFilters(new URLSearchParams("assignee=u1,u2"), meId);
+    const where = buildTaskWhere(projectId, filters);
+    expect(where).toEqual({
+      projectId,
+      assigneeId: { in: ["u1", "u2"] },
+    });
+  });
+
+  it("supports unassigned shortcut alone", () => {
+    const filters = parseTaskFilters(new URLSearchParams("assignee=unassigned"), meId);
+    const where = buildTaskWhere(projectId, filters);
+    expect(where).toEqual({
+      projectId,
+      assigneeId: null,
+    });
+  });
+
+  it("supports 'me' shortcut alone", () => {
+    const filters = parseTaskFilters(new URLSearchParams("assignee=me"), meId);
+    const where = buildTaskWhere(projectId, filters);
+    expect(where).toEqual({
+      projectId,
+      assigneeId: meId,
+    });
+  });
+
+  it("supports combining unassigned + ids + me into an OR list", () => {
+    const filters = parseTaskFilters(
+      new URLSearchParams("assignee=me,unassigned,u9"),
+      meId
+    );
+    const where = buildTaskWhere(projectId, filters);
+    expect(where).toEqual({
+      projectId,
+      OR: [
+        { assigneeId: { in: ["u9", meId] } },
+        { assigneeId: null },
+      ],
+    });
+  });
+
+  it("filters by search across title and description (case-insensitive)", () => {
+    const filters = parseTaskFilters(new URLSearchParams("search=login"), meId);
+    const where = buildTaskWhere(projectId, filters);
+    expect(where).toEqual({
+      projectId,
+      OR: [
+        { title: { contains: "login", mode: "insensitive" } },
+        { description: { contains: "login", mode: "insensitive" } },
+      ],
+    });
+  });
+
+  it("combines all filters with AND across categories", () => {
+    const filters = parseTaskFilters(
+      new URLSearchParams(
+        "priority=HIGH&status=s1&assignee=me&search=auth"
+      ),
+      meId
+    );
+    const where = buildTaskWhere(projectId, filters);
+    expect(where.projectId).toBe(projectId);
+    expect(where.priority).toEqual({ in: ["HIGH"] });
+    expect(where.statusId).toEqual({ in: ["s1"] });
+    expect(where.assigneeId).toBe(meId);
+    // Single-branch assignee leaves the OR slot free, so search lives there.
+    expect(where.OR).toEqual([
+      { title: { contains: "auth", mode: "insensitive" } },
+      { description: { contains: "auth", mode: "insensitive" } },
+    ]);
+    expect(where.AND).toBeUndefined();
+  });
+
+  it("merges assignee OR with search AND clauses", () => {
+    const filters = parseTaskFilters(
+      new URLSearchParams("assignee=me,unassigned&search=foo"),
+      meId
+    );
+    const where = buildTaskWhere(projectId, filters);
+    // assignee fan-out goes into top-level OR; search becomes its own AND group
+    expect(where.OR).toEqual([
+      { assigneeId: { in: [meId] } },
+      { assigneeId: null },
+    ]);
+    expect(where.AND).toEqual([
+      {
+        OR: [
+          { title: { contains: "foo", mode: "insensitive" } },
+          { description: { contains: "foo", mode: "insensitive" } },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/src/app/(dashboard)/projects/[id]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
-import { Board } from "@/components/board/board";
+import { BoardWithFilters } from "@/components/board/board-with-filters";
 import { ProjectTabs } from "@/components/projects/project-tabs";
 
 export default async function ProjectPage({
@@ -80,10 +80,11 @@ export default async function ProjectPage({
         <ProjectTabs projectId={project.id} active="board" />
       </div>
 
-      <Board
+      <BoardWithFilters
         project={project}
         initialTasks={tasks}
         members={project.members.map((m) => m.user)}
+        currentUser={user!}
       />
     </div>
   );

--- a/src/app/api/projects/[id]/tasks/route.ts
+++ b/src/app/api/projects/[id]/tasks/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
 import { createTaskSchema } from "@/lib/validations";
+import { buildTaskWhere, parseTaskFilters } from "@/lib/task-filters";
 
 export async function GET(
   request: NextRequest,
@@ -23,8 +24,11 @@ export async function GET(
       return NextResponse.json({ error: "Not a member of this project" }, { status: 403 });
     }
 
+    const filters = parseTaskFilters(request.nextUrl.searchParams, user.id);
+    const where = buildTaskWhere(id, filters);
+
     const tasks = await prisma.task.findMany({
-      where: { projectId: id },
+      where,
       include: {
         assignee: { select: { id: true, email: true, name: true, avatarUrl: true, role: true, createdAt: true } },
         creator: { select: { id: true, email: true, name: true, avatarUrl: true, role: true, createdAt: true } },

--- a/src/components/board/board-with-filters.tsx
+++ b/src/components/board/board-with-filters.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Board } from "./board";
+import { TaskFilterBar, TaskFilterState } from "./task-filter-bar";
+import type { Priority, ProjectWithMembers, Task, User } from "@/types";
+
+interface BoardWithFiltersProps {
+  project: ProjectWithMembers;
+  initialTasks: Task[];
+  members: User[];
+  currentUser: User;
+}
+
+const EMPTY_FILTERS: TaskFilterState = {
+  assigneeIds: [],
+  includeMe: false,
+  includeUnassigned: false,
+  priorities: [],
+  statusIds: [],
+  search: "",
+};
+
+const VALID_PRIORITIES: Priority[] = ["LOW", "MEDIUM", "HIGH", "URGENT"];
+
+function filtersFromSearchParams(
+  params: URLSearchParams | null
+): TaskFilterState {
+  if (!params) return { ...EMPTY_FILTERS };
+
+  const splitCsv = (raw: string | null) =>
+    raw
+      ? raw
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+
+  const rawAssignees = splitCsv(params.get("assignee"));
+  const assigneeIds: string[] = [];
+  let includeMe = false;
+  let includeUnassigned = false;
+  for (const v of rawAssignees) {
+    const lower = v.toLowerCase();
+    if (lower === "me") includeMe = true;
+    else if (lower === "unassigned") includeUnassigned = true;
+    else assigneeIds.push(v);
+  }
+
+  const priorities = splitCsv(params.get("priority"))
+    .map((p) => p.toUpperCase() as Priority)
+    .filter((p) => VALID_PRIORITIES.includes(p));
+
+  return {
+    assigneeIds,
+    includeMe,
+    includeUnassigned,
+    priorities,
+    statusIds: splitCsv(params.get("status")),
+    search: (params.get("search") ?? "").trim(),
+  };
+}
+
+function filtersToQueryString(filters: TaskFilterState): string {
+  const params = new URLSearchParams();
+  const assignees: string[] = [];
+  if (filters.includeMe) assignees.push("me");
+  if (filters.includeUnassigned) assignees.push("unassigned");
+  assignees.push(...filters.assigneeIds);
+  if (assignees.length > 0) params.set("assignee", assignees.join(","));
+  if (filters.priorities.length > 0)
+    params.set("priority", (filters.priorities as string[]).join(","));
+  if (filters.statusIds.length > 0)
+    params.set("status", filters.statusIds.join(","));
+  if (filters.search.trim().length > 0) params.set("search", filters.search.trim());
+  return params.toString();
+}
+
+function isFilterActive(filters: TaskFilterState): boolean {
+  return (
+    filters.priorities.length > 0 ||
+    filters.statusIds.length > 0 ||
+    filters.assigneeIds.length > 0 ||
+    filters.includeMe ||
+    filters.includeUnassigned ||
+    filters.search.trim().length > 0
+  );
+}
+
+export function BoardWithFilters({
+  project,
+  initialTasks,
+  members,
+  currentUser,
+}: BoardWithFiltersProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [filters, setFilters] = useState<TaskFilterState>(() =>
+    filtersFromSearchParams(searchParams)
+  );
+  const [tasks, setTasks] = useState<Task[]>(initialTasks);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const filtersActive = useMemo(() => isFilterActive(filters), [filters]);
+
+  // Sync URL whenever filters change.
+  useEffect(() => {
+    const qs = filtersToQueryString(filters);
+    const target = qs.length > 0 ? `${pathname}?${qs}` : pathname;
+    // Avoid pushing duplicate URLs onto history; replace gives bookmarkable URLs
+    // without breaking the back button.
+    router.replace(target);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters]);
+
+  // Fetch filtered tasks whenever filters change. We skip the very first render
+  // because the server already supplied the unfiltered initial list.
+  const isFirstRun = useRef(true);
+  const fetchSeq = useRef(0);
+
+  useEffect(() => {
+    if (isFirstRun.current) {
+      isFirstRun.current = false;
+      // If the URL had filters at mount, fall through to fetch the filtered set.
+      if (!filtersActive) return;
+    }
+
+    const seq = ++fetchSeq.current;
+    setIsLoading(true);
+    const qs = filtersToQueryString(filters);
+    const url = `/api/projects/${project.id}/tasks${qs ? `?${qs}` : ""}`;
+
+    fetch(url)
+      .then(async (res) => {
+        if (!res.ok) throw new Error("Failed to load tasks");
+        const data = await res.json();
+        if (seq !== fetchSeq.current) return; // stale
+        setTasks(data.tasks ?? []);
+      })
+      .catch((err) => {
+        console.error("Filter fetch failed", err);
+      })
+      .finally(() => {
+        if (seq === fetchSeq.current) setIsLoading(false);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters]);
+
+  const handleFiltersChange = useCallback((next: TaskFilterState) => {
+    setFilters(next);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <TaskFilterBar
+        members={members}
+        currentUser={currentUser}
+        statuses={project.statuses}
+        filters={filters}
+        onFiltersChange={handleFiltersChange}
+      />
+      {isLoading && (
+        <div
+          data-testid="tasks-loading"
+          className="text-xs text-orange-500 font-medium"
+        >
+          Loading tasks…
+        </div>
+      )}
+      <Board
+        project={project}
+        initialTasks={tasks}
+        members={members}
+        filtersActive={filtersActive}
+      />
+    </div>
+  );
+}

--- a/src/components/board/board.tsx
+++ b/src/components/board/board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DndContext, DragEndEvent, DragOverlay, DragStartEvent, closestCorners, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { Column } from "./column";
 import { TaskCard } from "./task-card";
@@ -13,13 +13,22 @@ interface BoardProps {
   project: ProjectWithMembers;
   initialTasks: Task[];
   members: User[];
+  /** When true, columns swap their empty-state copy to "no tasks match your filters". */
+  filtersActive?: boolean;
 }
 
-export function Board({ project, initialTasks, members }: BoardProps) {
+export function Board({ project, initialTasks, members, filtersActive = false }: BoardProps) {
   const [tasks, setTasks] = useState<Task[]>(initialTasks);
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  // Sync local state when the parent supplies a new task list (e.g. filter
+  // refetch). We don't try to merge optimistic edits with refetched results —
+  // the parent is the source of truth for the tasks visible on the board.
+  useEffect(() => {
+    setTasks(initialTasks);
+  }, [initialTasks]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
@@ -120,6 +129,7 @@ export function Board({ project, initialTasks, members }: BoardProps) {
               status={column.status}
               tasks={column.tasks}
               onTaskClick={setSelectedTask}
+              filtersActive={filtersActive}
             />
           ))}
         </div>

--- a/src/components/board/column.tsx
+++ b/src/components/board/column.tsx
@@ -9,9 +9,11 @@ interface ColumnProps {
   status: Status;
   tasks: Task[];
   onTaskClick: (task: Task) => void;
+  /** When true, the empty state reads as "filtered to nothing" rather than "drop here". */
+  filtersActive?: boolean;
 }
 
-export function Column({ status, tasks, onTaskClick }: ColumnProps) {
+export function Column({ status, tasks, onTaskClick, filtersActive = false }: ColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: status.id });
 
   return (
@@ -38,7 +40,7 @@ export function Column({ status, tasks, onTaskClick }: ColumnProps) {
 
       {tasks.length === 0 && (
         <div className="rounded-xl border-2 border-dashed border-orange-200 p-4 text-center text-sm text-gray-400">
-          Drop tasks here
+          {filtersActive ? "No tasks match your filters" : "Drop tasks here"}
         </div>
       )}
     </div>

--- a/src/components/board/task-filter-bar.tsx
+++ b/src/components/board/task-filter-bar.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { Priority, Status, User } from "@/types";
+
+export interface TaskFilterState {
+  assigneeIds: string[];
+  includeMe: boolean;
+  includeUnassigned: boolean;
+  priorities: Priority[] | string[];
+  statusIds: string[];
+  search: string;
+}
+
+interface TaskFilterBarProps {
+  members: User[];
+  currentUser: User;
+  statuses: Status[];
+  filters: TaskFilterState;
+  onFiltersChange: (next: TaskFilterState) => void;
+}
+
+const PRIORITIES: Priority[] = ["LOW", "MEDIUM", "HIGH", "URGENT"];
+
+const PRIORITY_LABEL: Record<string, string> = {
+  LOW: "Low",
+  MEDIUM: "Medium",
+  HIGH: "High",
+  URGENT: "Urgent",
+};
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export function TaskFilterBar({
+  members,
+  currentUser,
+  statuses,
+  filters,
+  onFiltersChange,
+}: TaskFilterBarProps) {
+  const [searchDraft, setSearchDraft] = useState(filters.search);
+  const [openPanel, setOpenPanel] = useState<
+    "assignee" | "priority" | "status" | null
+  >(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Keep local draft in sync if filters.search changes externally (URL, clear-all).
+  useEffect(() => {
+    setSearchDraft(filters.search);
+  }, [filters.search]);
+
+  // Debounce search updates -> filters.
+  useEffect(() => {
+    if (searchDraft === filters.search) return;
+    const handle = setTimeout(() => {
+      onFiltersChange({ ...filters, search: searchDraft });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchDraft]);
+
+  // Global "/" focuses the search input — but not while typing in another input.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "/") return;
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      const tag = target.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const activeCount = useMemo(() => {
+    return (
+      filters.priorities.length +
+      filters.statusIds.length +
+      filters.assigneeIds.length +
+      (filters.includeMe ? 1 : 0) +
+      (filters.includeUnassigned ? 1 : 0) +
+      (filters.search.trim().length > 0 ? 1 : 0)
+    );
+  }, [filters]);
+
+  const togglePriority = (p: Priority) => {
+    const set = new Set(filters.priorities as Priority[]);
+    if (set.has(p)) set.delete(p);
+    else set.add(p);
+    onFiltersChange({ ...filters, priorities: Array.from(set) });
+  };
+
+  const toggleStatus = (id: string) => {
+    const set = new Set(filters.statusIds);
+    if (set.has(id)) set.delete(id);
+    else set.add(id);
+    onFiltersChange({ ...filters, statusIds: Array.from(set) });
+  };
+
+  const toggleAssignee = (id: string) => {
+    const set = new Set(filters.assigneeIds);
+    if (set.has(id)) set.delete(id);
+    else set.add(id);
+    onFiltersChange({ ...filters, assigneeIds: Array.from(set) });
+  };
+
+  const toggleMe = () =>
+    onFiltersChange({ ...filters, includeMe: !filters.includeMe });
+
+  const toggleUnassigned = () =>
+    onFiltersChange({
+      ...filters,
+      includeUnassigned: !filters.includeUnassigned,
+    });
+
+  const clearAll = () =>
+    onFiltersChange({
+      assigneeIds: [],
+      includeMe: false,
+      includeUnassigned: false,
+      priorities: [],
+      statusIds: [],
+      search: "",
+    });
+
+  const clearSearch = () => {
+    setSearchDraft("");
+    onFiltersChange({ ...filters, search: "" });
+  };
+
+  const memberById = useMemo(() => {
+    const map = new Map<string, User>();
+    for (const m of members) map.set(m.id, m);
+    return map;
+  }, [members]);
+
+  return (
+    <div className="rounded-2xl border border-orange-100 bg-white p-3 shadow-sm space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative flex-1 min-w-[220px]">
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchDraft}
+            onChange={(e) => setSearchDraft(e.target.value)}
+            placeholder="Search tasks (press / to focus)"
+            aria-label="Search tasks"
+            className="w-full h-10 rounded-lg border border-gray-200 bg-white pl-9 pr-9 text-sm text-gray-900 placeholder:text-gray-400 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/20 transition-colors"
+          />
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-4.35-4.35M11 19a8 8 0 110-16 8 8 0 010 16z"
+            />
+          </svg>
+          {searchDraft.length > 0 && (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={clearSearch}
+              className="absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6 rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            >
+              ×
+            </button>
+          )}
+        </div>
+
+        <FilterDropdown
+          label="Assignee"
+          isOpen={openPanel === "assignee"}
+          onToggle={() =>
+            setOpenPanel(openPanel === "assignee" ? null : "assignee")
+          }
+        >
+          <PanelRow>
+            <PillButton
+              label="Me"
+              active={filters.includeMe}
+              onClick={toggleMe}
+            />
+            <PillButton
+              label="Unassigned"
+              active={filters.includeUnassigned}
+              onClick={toggleUnassigned}
+            />
+          </PanelRow>
+          <PanelRow>
+            {members
+              .filter((m) => m.id !== currentUser.id)
+              .map((m) => (
+                <PillButton
+                  key={m.id}
+                  label={m.name}
+                  active={filters.assigneeIds.includes(m.id)}
+                  onClick={() => toggleAssignee(m.id)}
+                />
+              ))}
+          </PanelRow>
+        </FilterDropdown>
+
+        <FilterDropdown
+          label="Priority"
+          isOpen={openPanel === "priority"}
+          onToggle={() =>
+            setOpenPanel(openPanel === "priority" ? null : "priority")
+          }
+        >
+          <PanelRow>
+            {PRIORITIES.map((p) => (
+              <PillButton
+                key={p}
+                label={PRIORITY_LABEL[p]}
+                active={(filters.priorities as Priority[]).includes(p)}
+                onClick={() => togglePriority(p)}
+              />
+            ))}
+          </PanelRow>
+        </FilterDropdown>
+
+        <FilterDropdown
+          label="Status"
+          isOpen={openPanel === "status"}
+          onToggle={() =>
+            setOpenPanel(openPanel === "status" ? null : "status")
+          }
+        >
+          <PanelRow>
+            {statuses.map((s) => (
+              <PillButton
+                key={s.id}
+                label={s.name}
+                active={filters.statusIds.includes(s.id)}
+                onClick={() => toggleStatus(s.id)}
+              />
+            ))}
+          </PanelRow>
+        </FilterDropdown>
+
+        {activeCount > 0 && (
+          <span
+            data-testid="active-filter-count"
+            className="ml-1 inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-orange-500 px-2 text-xs font-semibold text-white"
+          >
+            {activeCount}
+          </span>
+        )}
+
+        {activeCount > 0 && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="ml-auto text-xs font-medium text-orange-600 hover:text-orange-700"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {/* Active filter chips */}
+      {activeCount > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {(filters.priorities as Priority[]).map((p) => (
+            <Chip
+              key={`p-${p}`}
+              testId={`filter-chip-priority-${p}`}
+              label={`Priority: ${PRIORITY_LABEL[p] ?? p}`}
+              onRemove={() => togglePriority(p)}
+            />
+          ))}
+          {filters.statusIds.map((sid) => {
+            const status = statuses.find((s) => s.id === sid);
+            return (
+              <Chip
+                key={`s-${sid}`}
+                testId={`filter-chip-status-${sid}`}
+                label={`Status: ${status?.name ?? sid}`}
+                onRemove={() => toggleStatus(sid)}
+              />
+            );
+          })}
+          {filters.includeMe && (
+            <Chip
+              testId="filter-chip-assignee-me"
+              label="Assignee: Me"
+              onRemove={toggleMe}
+            />
+          )}
+          {filters.includeUnassigned && (
+            <Chip
+              testId="filter-chip-assignee-unassigned"
+              label="Assignee: Unassigned"
+              onRemove={toggleUnassigned}
+            />
+          )}
+          {filters.assigneeIds.map((id) => {
+            const m = memberById.get(id);
+            return (
+              <Chip
+                key={`a-${id}`}
+                testId={`filter-chip-assignee-${id}`}
+                label={`Assignee: ${m?.name ?? id}`}
+                onRemove={() => toggleAssignee(id)}
+              />
+            );
+          })}
+          {filters.search.trim().length > 0 && (
+            <Chip
+              testId="filter-chip-search"
+              label={`Search: ${filters.search}`}
+              onRemove={clearSearch}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilterDropdown({
+  label,
+  isOpen,
+  onToggle,
+  children,
+}: {
+  label: string;
+  isOpen: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={onToggle}
+        className={`inline-flex items-center gap-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+          isOpen
+            ? "border-orange-500 bg-orange-50 text-orange-700"
+            : "border-gray-200 bg-white text-gray-700 hover:border-orange-300 hover:bg-orange-50"
+        }`}
+      >
+        {label}
+        <svg
+          className="h-3 w-3"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+      {isOpen && (
+        <div className="absolute left-0 top-full z-10 mt-2 min-w-[16rem] rounded-xl border border-orange-100 bg-white p-3 shadow-lg space-y-2">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PanelRow({ children }: { children: React.ReactNode }) {
+  return <div className="flex flex-wrap gap-2">{children}</div>;
+}
+
+function PillButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+        active
+          ? "border-orange-500 bg-orange-500 text-white"
+          : "border-gray-200 bg-white text-gray-700 hover:border-orange-300 hover:bg-orange-50"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function Chip({
+  label,
+  onRemove,
+  testId,
+}: {
+  label: string;
+  onRemove: () => void;
+  testId: string;
+}) {
+  return (
+    <span
+      data-testid={testId}
+      className="inline-flex items-center gap-1 rounded-full bg-orange-50 px-2.5 py-1 text-xs font-medium text-orange-700 border border-orange-200"
+    >
+      {label}
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${label}`}
+        className="rounded-full text-orange-500 hover:text-orange-700"
+      >
+        ×
+      </button>
+    </span>
+  );
+}

--- a/src/lib/task-filters.ts
+++ b/src/lib/task-filters.ts
@@ -1,0 +1,156 @@
+import type { Prisma, Priority } from "@prisma/client";
+
+const VALID_PRIORITIES: ReadonlyArray<Priority> = ["LOW", "MEDIUM", "HIGH", "URGENT"];
+
+export interface TaskFilters {
+  /** Explicit user ids to include. */
+  assigneeIds: string[];
+  /** Whether the "Unassigned" shortcut is active (assigneeId IS NULL). */
+  includeUnassigned: boolean;
+  /** Whether the "Me" shortcut is active (assigneeId === currentUserId). */
+  includeMe: boolean;
+  /** Priorities (uppercase, validated against the Prisma enum). */
+  priorities: Priority[];
+  /** Status ids (no validation — Prisma will simply match nothing on bad ids). */
+  statusIds: string[];
+  /** Free-text search applied to title + description. */
+  search: string;
+  /** Resolved current user id (used to materialise the "me" shortcut). */
+  meId: string;
+}
+
+const splitCsv = (raw: string | null): string[] =>
+  raw
+    ? raw
+        .split(",")
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0)
+    : [];
+
+/**
+ * Parses task filter query params into a normalised, validated structure.
+ * Invalid values are silently dropped — filtering should never surface 400s
+ * for "looks weird" input. Auth/scope errors are out of scope here.
+ */
+export function parseTaskFilters(
+  params: URLSearchParams,
+  currentUserId: string
+): TaskFilters {
+  const rawAssignees = splitCsv(params.get("assignee"));
+  const rawPriorities = splitCsv(params.get("priority"));
+  const rawStatuses = splitCsv(params.get("status"));
+  const rawSearch = params.get("search") ?? "";
+
+  const assigneeIds: string[] = [];
+  let includeUnassigned = false;
+  let includeMe = false;
+  for (const value of rawAssignees) {
+    const lower = value.toLowerCase();
+    if (lower === "unassigned") {
+      includeUnassigned = true;
+    } else if (lower === "me") {
+      includeMe = true;
+    } else {
+      assigneeIds.push(value);
+    }
+  }
+
+  const priorities = rawPriorities
+    .map((p) => p.toUpperCase())
+    .filter((p): p is Priority =>
+      (VALID_PRIORITIES as ReadonlyArray<string>).includes(p)
+    );
+
+  return {
+    assigneeIds,
+    includeUnassigned,
+    includeMe,
+    priorities,
+    statusIds: rawStatuses,
+    search: rawSearch.trim(),
+    meId: currentUserId,
+  };
+}
+
+/**
+ * Composes a Prisma `where` fragment for `Task.findMany` from a parsed filter
+ * object scoped to a single project.
+ *
+ * Strategy:
+ *   - priorities and statusIds become single-column `in` constraints (OR within).
+ *   - Assignee branch: explicit ids and "me" merge into a single `assigneeId.in`
+ *     set; "unassigned" is `assigneeId IS NULL`. When both kinds are present we
+ *     fan out into a top-level `OR` so they union.
+ *   - Search becomes a nested `OR` across title/description placed under `AND`
+ *     so it does not collide with the assignee `OR`.
+ */
+export function buildTaskWhere(
+  projectId: string,
+  filters: TaskFilters
+): Prisma.TaskWhereInput {
+  const where: Prisma.TaskWhereInput = { projectId };
+
+  if (filters.priorities.length > 0) {
+    where.priority = { in: filters.priorities };
+  }
+
+  if (filters.statusIds.length > 0) {
+    where.statusId = { in: filters.statusIds };
+  }
+
+  const mergedIds = [...filters.assigneeIds];
+  if (filters.includeMe) {
+    mergedIds.push(filters.meId);
+  }
+
+  const assigneeBranches: Prisma.TaskWhereInput[] = [];
+  if (mergedIds.length > 0) {
+    assigneeBranches.push({ assigneeId: { in: mergedIds } });
+  }
+  if (filters.includeUnassigned) {
+    assigneeBranches.push({ assigneeId: null });
+  }
+
+  // If only one assignee branch, inline scalar/in onto where; if multiple, OR.
+  if (assigneeBranches.length === 1) {
+    const [branch] = assigneeBranches;
+    if ("assigneeId" in branch) {
+      const assigneeValue = branch.assigneeId;
+      // Single explicit id (no unassigned) collapses `in: [x]` → scalar `x`.
+      if (
+        assigneeValue &&
+        typeof assigneeValue === "object" &&
+        "in" in assigneeValue &&
+        Array.isArray(assigneeValue.in) &&
+        assigneeValue.in.length === 1
+      ) {
+        where.assigneeId = assigneeValue.in[0];
+      } else {
+        where.assigneeId = assigneeValue;
+      }
+    }
+  }
+
+  const searchBranch: Prisma.TaskWhereInput | null =
+    filters.search.length > 0
+      ? {
+          OR: [
+            { title: { contains: filters.search, mode: "insensitive" } },
+            { description: { contains: filters.search, mode: "insensitive" } },
+          ],
+        }
+      : null;
+
+  // Decide where to place OR groups so they don't collide on the same key.
+  if (assigneeBranches.length > 1 && searchBranch) {
+    where.OR = assigneeBranches;
+    where.AND = [searchBranch];
+  } else if (assigneeBranches.length > 1) {
+    where.OR = assigneeBranches;
+  } else if (searchBranch) {
+    // No assignee OR fan-out — search can use the top-level OR slot.
+    where.OR = searchBranch.OR;
+  }
+
+  return where;
+}


### PR DESCRIPTION
## Summary

- Adds an end-to-end task filtering experience on the project board (issue #2): assignee multi-select with **Me** and **Unassigned** shortcuts, priority multi-select, status multi-select, and free-text search across title and description.
- Filtering happens **server-side** via the existing `GET /api/projects/[id]/tasks` endpoint. A new `src/lib/task-filters.ts` exposes `parseTaskFilters` and `buildTaskWhere` so the where-clause is unit-testable in isolation; the route delegates to these helpers.
- Filter state is **encoded in the URL query string** (shareable / bookmarkable). On mount, filters hydrate from the URL. As the user changes filters, the URL is replaced and the task list is refetched.
- Adds a `TaskFilterBar` component with active filter chips, an active-filter count badge, a "Clear all" action, and a search input that supports the `/` keyboard shortcut to focus and a clear button. Search input is **debounced 300ms** before triggering a request.
- Each board column shows a "**No tasks match your filters**" empty state (replacing the default "Drop tasks here") when filters are active.

## Choices and notes

- **Hybrid fetching**: the project page keeps its existing server-side initial fetch (fast first paint) but the new client-side wrapper takes over after mount and re-fetches via the API on filter changes. The alternative (refactor to fully client-side fetching) was rejected to avoid reintroducing a flash of empty board on navigation.
- **Filter combination semantics**: AND across categories, OR within a category — implemented in `buildTaskWhere`. Single-branch assignee filters collapse to a scalar `assigneeId` (or `assigneeId.in`); when both explicit ids and `Unassigned` are present we fan out into a top-level `OR`. Search occupies the top-level `OR` slot when it does not collide with the assignee branch, otherwise it nests under `AND`.
- **Invalid params are silently ignored** (e.g. `priority=BANANA`), per the issue's "gracefully ignored" requirement.
- **Out of scope (explicitly)**: due-date filtering. The `Task` model has no `dueDate` field, so per the issue's caveat we descoped it. Adding a `dueDate` is a separate change. Labels/tags also remain out of scope (the model has none yet).
- **Lint/build environment note**: when running `npm run lint` or `npm run build` from inside a git worktree under `.claude/worktrees/`, ESLint complains about a duplicated plugin between the worktree and parent `.eslintrc.json`. This is a worktree-only artefact — running the same commands from the repo root succeeds and the production build still completes (the eslint warning is non-blocking).

## Test plan

- [x] `npm test` — 260 passing (54 new tests across 4 new suites: `task-filters.test.ts`, `tasks-filtering.test.ts`, `TaskFilterBar.test.tsx`, `BoardWithFilters.test.tsx`, plus 1 new `Column.test.tsx`).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` succeeds (production bundle generated).
- [ ] Manual smoke: open a project board, apply each filter individually and combined, confirm chips and count, copy URL, paste in a new tab, confirm filters re-hydrate.
- [ ] Manual smoke: focus another input on the page and press `/` — focus should NOT jump to the search input.

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)