### PR TITLE
feat: add dark theme as user preference

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,14 +9,15 @@ datasource db {
 }
 
 model User {
-  id        String     @id @default(cuid())
-  email     String     @unique
-  password  String
-  name      String
-  avatarUrl String?
-  role      SystemRole @default(USER)
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
+  id               String           @id @default(cuid())
+  email            String           @unique
+  password         String
+  name             String
+  avatarUrl        String?
+  role             SystemRole       @default(USER)
+  themePreference  ThemePreference  @default(SYSTEM)
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
 
   projects                ProjectMember[]
   assignedTasks           Task[]          @relation("AssignedTasks")
@@ -49,6 +50,12 @@ model PersonalAccessToken {
 enum SystemRole {
   USER
   ADMIN
+}
+
+enum ThemePreference {
+  LIGHT
+  DARK
+  SYSTEM
 }
 
 model Project {

--- a/src/__tests__/api/auth-me-pat.test.ts
+++ b/src/__tests__/api/auth-me-pat.test.ts
@@ -44,6 +44,7 @@ const userRow = {
   name: "User",
   avatarUrl: null,
   role: "USER" as const,
+  themePreference: "SYSTEM" as const,
   createdAt: new Date("2024-01-01"),
 };
 

--- a/src/__tests__/api/auth/me.test.ts
+++ b/src/__tests__/api/auth/me.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @jest-environment node
+ *
+ * Tests `GET /api/auth/me` and `PATCH /api/auth/me`. Prisma and the auth
+ * helpers are mocked so we can verify the route handlers in isolation.
+ */
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import { GET, PATCH } from "@/app/api/auth/me/route";
+
+const mockedAuth = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
+const mockedPrisma = prisma as unknown as {
+  user: { update: jest.Mock };
+};
+
+const baseUser = {
+  id: "user-1",
+  email: "demo@example.com",
+  name: "Demo User",
+  avatarUrl: null,
+  role: "USER" as const,
+  themePreference: "SYSTEM" as const,
+  createdAt: new Date("2024-01-01"),
+};
+
+function makePatch(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/auth/me", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("GET /api/auth/me", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the user when authenticated", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.id).toBe("user-1");
+    expect(body.user.themePreference).toBe("SYSTEM");
+  });
+});
+
+describe("PATCH /api/auth/me", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const res = await PATCH(makePatch({ name: "New" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("updates the name when provided a valid payload", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    mockedPrisma.user.update.mockResolvedValue({
+      ...baseUser,
+      name: "Renamed",
+    });
+
+    const res = await PATCH(makePatch({ name: "Renamed" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.name).toBe("Renamed");
+    expect(mockedPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: expect.objectContaining({ name: "Renamed" }),
+      })
+    );
+  });
+
+  it("rejects an invalid name with a 400", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    const res = await PATCH(makePatch({ name: "" }));
+    expect(res.status).toBe(400);
+    expect(mockedPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("accepts a themePreference of DARK", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    mockedPrisma.user.update.mockResolvedValue({
+      ...baseUser,
+      themePreference: "DARK",
+    });
+
+    const res = await PATCH(
+      makePatch({ name: "Demo User", themePreference: "DARK" })
+    );
+    expect(res.status).toBe(200);
+    expect(mockedPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ themePreference: "DARK" }),
+      })
+    );
+    const body = await res.json();
+    expect(body.user.themePreference).toBe("DARK");
+  });
+
+  it("accepts a themePreference of LIGHT", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    mockedPrisma.user.update.mockResolvedValue({
+      ...baseUser,
+      themePreference: "LIGHT",
+    });
+
+    const res = await PATCH(
+      makePatch({ name: "Demo User", themePreference: "LIGHT" })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.themePreference).toBe("LIGHT");
+  });
+
+  it("accepts a themePreference of SYSTEM", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    mockedPrisma.user.update.mockResolvedValue({
+      ...baseUser,
+      themePreference: "SYSTEM",
+    });
+
+    const res = await PATCH(
+      makePatch({ name: "Demo User", themePreference: "SYSTEM" })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.themePreference).toBe("SYSTEM");
+  });
+
+  it("rejects an invalid themePreference with a 400", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    const res = await PATCH(
+      makePatch({ name: "Demo User", themePreference: "AUTO" })
+    );
+    expect(res.status).toBe(400);
+    expect(mockedPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("returns themePreference in the selected fields", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    mockedPrisma.user.update.mockResolvedValue({
+      ...baseUser,
+      themePreference: "DARK",
+    });
+
+    await PATCH(makePatch({ name: "Demo User", themePreference: "DARK" }));
+    const updateCall = mockedPrisma.user.update.mock.calls[0][0];
+    expect(updateCall.select).toEqual(
+      expect.objectContaining({ themePreference: true })
+    );
+  });
+});

--- a/src/__tests__/api/auth/me.test.ts
+++ b/src/__tests__/api/auth/me.test.ts
@@ -18,11 +18,19 @@ jest.mock("@/lib/auth", () => ({
   getCurrentUser: jest.fn(),
 }));
 
+jest.mock("@/lib/auth-pat", () => ({
+  getCurrentUserOrPATUser: jest.fn(),
+}));
+
 import { prisma } from "@/lib/prisma";
 import { getCurrentUser } from "@/lib/auth";
+import { getCurrentUserOrPATUser } from "@/lib/auth-pat";
 import { GET, PATCH } from "@/app/api/auth/me/route";
 
 const mockedAuth = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
+const mockedAuthOrPAT = getCurrentUserOrPATUser as jest.MockedFunction<
+  typeof getCurrentUserOrPATUser
+>;
 const mockedPrisma = prisma as unknown as {
   user: { update: jest.Mock };
 };
@@ -45,20 +53,24 @@ function makePatch(body: Record<string, unknown>) {
   });
 }
 
+function makeGet() {
+  return new NextRequest("http://localhost/api/auth/me", { method: "GET" });
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
 describe("GET /api/auth/me", () => {
   it("returns 401 when unauthenticated", async () => {
-    mockedAuth.mockResolvedValue(null);
-    const res = await GET();
+    mockedAuthOrPAT.mockResolvedValue(null);
+    const res = await GET(makeGet());
     expect(res.status).toBe(401);
   });
 
   it("returns the user when authenticated", async () => {
-    mockedAuth.mockResolvedValue(baseUser);
-    const res = await GET();
+    mockedAuthOrPAT.mockResolvedValue({ user: baseUser, source: "session" });
+    const res = await GET(makeGet());
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.user.id).toBe("user-1");

--- a/src/__tests__/api/auth/me.test.ts
+++ b/src/__tests__/api/auth/me.test.ts
@@ -69,7 +69,7 @@ describe("GET /api/auth/me", () => {
   });
 
   it("returns the user when authenticated", async () => {
-    mockedAuthOrPAT.mockResolvedValue({ user: baseUser, source: "session" });
+    mockedAuthOrPAT.mockResolvedValue({ user: baseUser, viaPAT: false });
     const res = await GET(makeGet());
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/src/__tests__/api/tokens.test.ts
+++ b/src/__tests__/api/tokens.test.ts
@@ -60,6 +60,7 @@ const userRow = {
   name: "User",
   avatarUrl: null,
   role: "USER" as const,
+  themePreference: "SYSTEM" as const,
   createdAt: new Date("2024-01-01"),
 };
 

--- a/src/__tests__/api/users/preferences.test.ts
+++ b/src/__tests__/api/users/preferences.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ *
+ * Tests `PATCH /api/users/me/preferences` — the dedicated endpoint for
+ * updating just the user's theme preference.
+ */
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
+import { PATCH } from "@/app/api/users/me/preferences/route";
+
+const mockedAuth = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
+const mockedPrisma = prisma as unknown as {
+  user: { update: jest.Mock };
+};
+
+const baseUser = {
+  id: "user-1",
+  email: "demo@example.com",
+  name: "Demo User",
+  avatarUrl: null,
+  role: "USER" as const,
+  themePreference: "SYSTEM" as const,
+  createdAt: new Date("2024-01-01"),
+};
+
+function makePatch(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/users/me/preferences", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("PATCH /api/users/me/preferences", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockedAuth.mockResolvedValue(null);
+    const res = await PATCH(makePatch({ themePreference: "DARK" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("updates the user's theme preference to DARK", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    mockedPrisma.user.update.mockResolvedValue({
+      ...baseUser,
+      themePreference: "DARK",
+    });
+
+    const res = await PATCH(makePatch({ themePreference: "DARK" }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.user.themePreference).toBe("DARK");
+    expect(mockedPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: { themePreference: "DARK" },
+      })
+    );
+  });
+
+  it("updates the user's theme preference to LIGHT", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    mockedPrisma.user.update.mockResolvedValue({
+      ...baseUser,
+      themePreference: "LIGHT",
+    });
+
+    const res = await PATCH(makePatch({ themePreference: "LIGHT" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.themePreference).toBe("LIGHT");
+  });
+
+  it("updates the user's theme preference to SYSTEM", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    mockedPrisma.user.update.mockResolvedValue({
+      ...baseUser,
+      themePreference: "SYSTEM",
+    });
+
+    const res = await PATCH(makePatch({ themePreference: "SYSTEM" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.themePreference).toBe("SYSTEM");
+  });
+
+  it("rejects an unknown themePreference value with 400", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    const res = await PATCH(makePatch({ themePreference: "AUTO" }));
+    expect(res.status).toBe(400);
+    expect(mockedPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing themePreference with 400", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    const res = await PATCH(makePatch({}));
+    expect(res.status).toBe(400);
+    expect(mockedPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("ignores unknown fields in the payload", async () => {
+    mockedAuth.mockResolvedValue(baseUser);
+    mockedPrisma.user.update.mockResolvedValue({
+      ...baseUser,
+      themePreference: "DARK",
+    });
+
+    const res = await PATCH(
+      makePatch({ themePreference: "DARK", role: "ADMIN", name: "Hacked" })
+    );
+    expect(res.status).toBe(200);
+    const updateCall = mockedPrisma.user.update.mock.calls[0][0];
+    expect(updateCall.data).toEqual({ themePreference: "DARK" });
+  });
+});

--- a/src/__tests__/api/vulnerabilities.test.ts
+++ b/src/__tests__/api/vulnerabilities.test.ts
@@ -53,6 +53,7 @@ const adminUser = {
   name: "Admin",
   avatarUrl: null,
   role: "USER" as const,
+  themePreference: "SYSTEM" as const,
   createdAt: new Date("2024-01-01"),
 };
 

--- a/src/__tests__/components/Board.darkmode.test.tsx
+++ b/src/__tests__/components/Board.darkmode.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Verifies that key board surfaces opt into dark-mode styling via the
+ * `dark:` Tailwind variants. We don't render an actual JSDOM-styled tree
+ * here — Tailwind doesn't run in tests — so we assert the presence of
+ * `dark:*` utility classes on the rendered className strings.
+ */
+import { render } from "@testing-library/react";
+import { Column } from "@/components/board/column";
+import { TaskCard } from "@/components/board/task-card";
+import { DndContext } from "@dnd-kit/core";
+import type { Task, Status } from "@/types";
+
+const todoStatus: Status = {
+  id: "s1",
+  name: "To Do",
+  order: 0,
+  projectId: "p1",
+};
+
+const baseTask: Task = {
+  id: "t1",
+  title: "Test task",
+  description: null,
+  key: "P-1",
+  priority: "MEDIUM",
+  order: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  projectId: "p1",
+  statusId: "s1",
+  assigneeId: null,
+  creatorId: "u1",
+};
+
+describe("Board dark mode", () => {
+  it("Column declares dark-mode utility classes", () => {
+    const { container } = render(
+      <DndContext>
+        <Column status={todoStatus} tasks={[]} onTaskClick={() => {}} />
+      </DndContext>
+    );
+    const html = container.innerHTML;
+    // The column wrapper, header, count badge, and empty state all need
+    // dark variants for legibility.
+    expect(html).toMatch(/dark:bg-dark-surface/);
+    expect(html).toMatch(/dark:text-dark-text-primary/);
+    expect(html).toMatch(/dark:border-dark-border|dark:text-dark-text-secondary/);
+  });
+
+  it("TaskCard declares dark-mode utility classes", () => {
+    const { container } = render(
+      <DndContext>
+        <Column status={todoStatus} tasks={[baseTask]} onTaskClick={() => {}} />
+      </DndContext>
+    );
+    const html = container.innerHTML;
+    // Key, title, and surface should all have dark-mode treatment so the
+    // orange primary remains vibrant against neutral-800/900 backgrounds.
+    expect(html).toMatch(/dark:bg-dark-surface-hover/);
+    expect(html).toMatch(/dark:text-dark-text-primary/);
+    expect(html).toMatch(/dark:text-orange-400/);
+  });
+});

--- a/src/__tests__/components/ProfilePage.test.tsx
+++ b/src/__tests__/components/ProfilePage.test.tsx
@@ -1,6 +1,30 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@/components/theme/theme-provider";
 import ProfilePage from "@/app/(dashboard)/profile/page";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches: false,
+      media: "(prefers-color-scheme: dark)",
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+const renderProfile = () =>
+  render(
+    <ThemeProvider initialPreference="SYSTEM" persistOnChange={false}>
+      <ProfilePage />
+    </ThemeProvider>
+  );
 
 jest.mock("@/components/ui", () => {
   const React = require("react");
@@ -79,6 +103,7 @@ const mockAdmin = {
   name: "Admin User",
   avatarUrl: null,
   role: "ADMIN",
+  themePreference: "SYSTEM",
   createdAt: "2024-01-01T00:00:00.000Z",
 };
 
@@ -88,6 +113,7 @@ const mockUser = {
   name: "Demo User",
   avatarUrl: null,
   role: "USER",
+  themePreference: "SYSTEM",
   createdAt: "2024-01-01T00:00:00.000Z",
 };
 
@@ -102,7 +128,7 @@ describe("ProfilePage", () => {
       json: async () => ({ user: mockUser }),
     });
 
-    render(<ProfilePage />);
+    renderProfile();
 
     await waitFor(() => {
       expect(screen.getByLabelText(/^name$/i)).toHaveValue("Demo User");
@@ -120,7 +146,7 @@ describe("ProfilePage", () => {
       json: async () => ({ user: mockAdmin }),
     });
 
-    render(<ProfilePage />);
+    renderProfile();
 
     await waitFor(() => {
       expect(screen.getByLabelText(/^name$/i)).toHaveValue("Admin User");
@@ -143,7 +169,7 @@ describe("ProfilePage", () => {
         json: async () => ({ user: { ...mockUser, name: "New Name" } }),
       });
 
-    render(<ProfilePage />);
+    renderProfile();
 
     await waitFor(() => {
       expect(screen.getByLabelText(/^name$/i)).toHaveValue("Demo User");
@@ -172,7 +198,7 @@ describe("ProfilePage", () => {
       json: async () => ({ error: "Unauthorized" }),
     });
 
-    render(<ProfilePage />);
+    renderProfile();
 
     await waitFor(() => {
       expect(screen.getByText(/unable to load profile/i)).toBeInTheDocument();
@@ -185,7 +211,7 @@ describe("ProfilePage", () => {
       json: async () => ({ user: mockUser }),
     });
 
-    render(<ProfilePage />);
+    renderProfile();
 
     await waitFor(() => {
       expect(screen.getByLabelText(/current password/i)).toBeInTheDocument();
@@ -209,7 +235,7 @@ describe("ProfilePage", () => {
         json: async () => ({ success: true }),
       });
 
-    render(<ProfilePage />);
+    renderProfile();
 
     await waitFor(() => {
       expect(screen.getByLabelText(/current password/i)).toBeInTheDocument();
@@ -236,6 +262,57 @@ describe("ProfilePage", () => {
     expect(body.confirmNewPassword).toBe("newpw456");
   });
 
+  it("renders the theme toggle with Light / Dark / System options", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ user: mockUser }),
+    });
+
+    renderProfile();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^name$/i)).toHaveValue("Demo User");
+    });
+
+    expect(screen.getByRole("radio", { name: /light/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /dark/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /system/i })).toBeInTheDocument();
+  });
+
+  it("PATCHes the preferences endpoint when theme is changed", async () => {
+    const user = userEvent.setup();
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ user: mockUser }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ user: { ...mockUser, themePreference: "DARK" } }),
+      });
+
+    render(
+      <ThemeProvider initialPreference="LIGHT" persistOnChange={true}>
+        <ProfilePage />
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/^name$/i)).toHaveValue("Demo User");
+    });
+
+    await user.click(screen.getByRole("radio", { name: /dark/i }));
+
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls;
+      const patchCall = calls.find(
+        (c) => c[0] === "/api/users/me/preferences" && c[1]?.method === "PATCH"
+      );
+      expect(patchCall).toBeDefined();
+      expect(JSON.parse(patchCall![1].body).themePreference).toBe("DARK");
+    });
+  });
+
   it("shows error when confirmation does not match new password", async () => {
     const user = userEvent.setup();
 
@@ -244,7 +321,7 @@ describe("ProfilePage", () => {
       json: async () => ({ user: mockUser }),
     });
 
-    render(<ProfilePage />);
+    renderProfile();
 
     await waitFor(() => {
       expect(screen.getByLabelText(/current password/i)).toBeInTheDocument();

--- a/src/__tests__/components/ThemeProvider.test.tsx
+++ b/src/__tests__/components/ThemeProvider.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * ThemeProvider tests.
+ *
+ * The provider:
+ *   - reads an initial preference (LIGHT | DARK | SYSTEM)
+ *   - applies `class="dark"` to <html> when the resolved theme is dark
+ *   - re-applies when preference changes via setThemePreference
+ *   - tracks the system color-scheme when preference is SYSTEM
+ */
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  ThemeProvider,
+  useTheme,
+  resolveTheme,
+} from "@/components/theme/theme-provider";
+
+function ThemeProbe() {
+  const { themePreference, resolvedTheme, setThemePreference } = useTheme();
+  return (
+    <div>
+      <span data-testid="preference">{themePreference}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
+      <button onClick={() => setThemePreference("DARK")}>set dark</button>
+      <button onClick={() => setThemePreference("LIGHT")}>set light</button>
+      <button onClick={() => setThemePreference("SYSTEM")}>set system</button>
+    </div>
+  );
+}
+
+type MqlListener = (e: { matches: boolean }) => void;
+
+function installMatchMedia(initialMatches = false) {
+  const listeners = new Set<MqlListener>();
+  const mql = {
+    matches: initialMatches,
+    media: "(prefers-color-scheme: dark)",
+    addEventListener: (_: "change", cb: MqlListener) => listeners.add(cb),
+    removeEventListener: (_: "change", cb: MqlListener) => listeners.delete(cb),
+    // Older API used in some tests
+    addListener: (cb: MqlListener) => listeners.add(cb),
+    removeListener: (cb: MqlListener) => listeners.delete(cb),
+    dispatchEvent: () => true,
+    onchange: null,
+  };
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: jest.fn().mockImplementation(() => mql),
+  });
+  return {
+    setMatches(value: boolean) {
+      mql.matches = value;
+      listeners.forEach((l) => l({ matches: value }));
+    },
+  };
+}
+
+beforeEach(() => {
+  document.documentElement.classList.remove("dark");
+  installMatchMedia(false);
+});
+
+describe("resolveTheme", () => {
+  it("returns 'dark' for DARK regardless of system", () => {
+    expect(resolveTheme("DARK", true)).toBe("dark");
+    expect(resolveTheme("DARK", false)).toBe("dark");
+  });
+
+  it("returns 'light' for LIGHT regardless of system", () => {
+    expect(resolveTheme("LIGHT", true)).toBe("light");
+    expect(resolveTheme("LIGHT", false)).toBe("light");
+  });
+
+  it("follows the system preference for SYSTEM", () => {
+    expect(resolveTheme("SYSTEM", true)).toBe("dark");
+    expect(resolveTheme("SYSTEM", false)).toBe("light");
+  });
+});
+
+describe("ThemeProvider", () => {
+  it("applies the 'dark' class when initial preference is DARK", () => {
+    render(
+      <ThemeProvider initialPreference="DARK">
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(screen.getByTestId("preference")).toHaveTextContent("DARK");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+  });
+
+  it("removes the 'dark' class when initial preference is LIGHT", () => {
+    document.documentElement.classList.add("dark");
+    render(
+      <ThemeProvider initialPreference="LIGHT">
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+  });
+
+  it("uses system preference when initial preference is SYSTEM (dark)", () => {
+    installMatchMedia(true);
+    render(
+      <ThemeProvider initialPreference="SYSTEM">
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+  });
+
+  it("uses system preference when initial preference is SYSTEM (light)", () => {
+    installMatchMedia(false);
+    render(
+      <ThemeProvider initialPreference="SYSTEM">
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+  });
+
+  it("toggles the 'dark' class when preference changes from LIGHT to DARK", async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider initialPreference="LIGHT">
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    await user.click(screen.getByRole("button", { name: /set dark/i }));
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(screen.getByTestId("preference")).toHaveTextContent("DARK");
+  });
+
+  it("reacts to system preference changes when set to SYSTEM", () => {
+    const mm = installMatchMedia(false);
+    render(
+      <ThemeProvider initialPreference="SYSTEM">
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    act(() => {
+      mm.setMatches(true);
+    });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("persists the preference to the API when changed", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ user: { themePreference: "DARK" } }),
+    });
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider initialPreference="LIGHT">
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: /set dark/i }));
+
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    const patchCall = calls.find((c) => c[1]?.method === "PATCH");
+    expect(patchCall).toBeDefined();
+    expect(patchCall![0]).toBe("/api/users/me/preferences");
+    expect(JSON.parse(patchCall![1].body).themePreference).toBe("DARK");
+  });
+
+  it("does not call the API when persistOnChange is false", async () => {
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider initialPreference="LIGHT" persistOnChange={false}>
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: /set dark/i }));
+
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    expect(calls.find((c) => c[1]?.method === "PATCH")).toBeUndefined();
+  });
+});

--- a/src/__tests__/components/ThemeToggle.test.tsx
+++ b/src/__tests__/components/ThemeToggle.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@/components/theme/theme-provider";
+import { ThemeToggle } from "@/components/theme/theme-toggle";
+
+beforeEach(() => {
+  document.documentElement.classList.remove("dark");
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches: false,
+      media: "(prefers-color-scheme: dark)",
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: async () => ({ user: {} }),
+  });
+});
+
+function renderWithProvider(initial: "LIGHT" | "DARK" | "SYSTEM" = "SYSTEM") {
+  return render(
+    <ThemeProvider initialPreference={initial} persistOnChange={false}>
+      <ThemeToggle />
+    </ThemeProvider>
+  );
+}
+
+describe("ThemeToggle", () => {
+  it("renders Light, Dark, and System options", () => {
+    renderWithProvider();
+    expect(screen.getByRole("radio", { name: /light/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /dark/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /system/i })).toBeInTheDocument();
+  });
+
+  it("marks the current preference as checked", () => {
+    renderWithProvider("DARK");
+    expect(screen.getByRole("radio", { name: /dark/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect(screen.getByRole("radio", { name: /light/i })).toHaveAttribute(
+      "aria-checked",
+      "false"
+    );
+  });
+
+  it("changes preference when an option is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProvider("LIGHT");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    await user.click(screen.getByRole("radio", { name: /dark/i }));
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(screen.getByRole("radio", { name: /dark/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+
+  it("returns to system preference when System is selected", async () => {
+    const user = userEvent.setup();
+    renderWithProvider("DARK");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    await user.click(screen.getByRole("radio", { name: /system/i }));
+
+    // System with prefers-color-scheme: light => no dark class
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+});

--- a/src/__tests__/lib/auth-pat.test.ts
+++ b/src/__tests__/lib/auth-pat.test.ts
@@ -52,6 +52,7 @@ const userRow = {
   name: "User",
   avatarUrl: null,
   role: "USER" as const,
+  themePreference: "SYSTEM" as const,
   createdAt: new Date("2024-01-01"),
 };
 

--- a/src/__tests__/lib/validations.test.ts
+++ b/src/__tests__/lib/validations.test.ts
@@ -3,6 +3,7 @@ import {
   addMemberSchema,
   updateMemberSchema,
   changePasswordSchema,
+  updateThemePreferenceSchema,
 } from "@/lib/validations";
 
 describe("updateProfileSchema", () => {
@@ -144,5 +145,74 @@ describe("changePasswordSchema", () => {
 
   it("rejects missing fields", () => {
     expect(changePasswordSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("updateProfileSchema with themePreference", () => {
+  it("accepts a valid themePreference: LIGHT", () => {
+    const result = updateProfileSchema.safeParse({
+      name: "Jane",
+      themePreference: "LIGHT",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a valid themePreference: DARK", () => {
+    const result = updateProfileSchema.safeParse({
+      name: "Jane",
+      themePreference: "DARK",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a valid themePreference: SYSTEM", () => {
+    const result = updateProfileSchema.safeParse({
+      name: "Jane",
+      themePreference: "SYSTEM",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid themePreference value", () => {
+    const result = updateProfileSchema.safeParse({
+      name: "Jane",
+      themePreference: "PURPLE",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("treats themePreference as optional", () => {
+    const result = updateProfileSchema.safeParse({ name: "Jane" });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("updateThemePreferenceSchema", () => {
+  it("accepts LIGHT", () => {
+    expect(
+      updateThemePreferenceSchema.safeParse({ themePreference: "LIGHT" }).success
+    ).toBe(true);
+  });
+
+  it("accepts DARK", () => {
+    expect(
+      updateThemePreferenceSchema.safeParse({ themePreference: "DARK" }).success
+    ).toBe(true);
+  });
+
+  it("accepts SYSTEM", () => {
+    expect(
+      updateThemePreferenceSchema.safeParse({ themePreference: "SYSTEM" }).success
+    ).toBe(true);
+  });
+
+  it("rejects unknown values", () => {
+    expect(
+      updateThemePreferenceSchema.safeParse({ themePreference: "AUTO" }).success
+    ).toBe(false);
+  });
+
+  it("rejects missing themePreference", () => {
+    expect(updateThemePreferenceSchema.safeParse({}).success).toBe(false);
   });
 });

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -15,7 +15,7 @@ export default async function DashboardLayout({
   }
 
   return (
-    <div className="flex h-screen bg-gradient-to-br from-orange-50/50 via-white to-amber-50/50">
+    <div className="flex h-screen bg-gradient-to-br from-orange-50/50 via-white to-amber-50/50 dark:from-dark-background dark:via-dark-surface dark:to-dark-background">
       <Sidebar user={user} />
       <div className="flex flex-1 flex-col overflow-hidden">
         <Header user={user} />

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/validations";
 import { Avatar, Badge, Button, Input } from "@/components/ui";
 import { PersonalAccessTokens } from "@/components/settings/PersonalAccessTokens";
+import { ThemeToggle } from "@/components/theme/theme-toggle";
 import { User } from "@/types";
 import { formatDate } from "@/lib/utils";
 
@@ -136,7 +137,7 @@ export default function ProfilePage() {
   if (loadError || !user) {
     return (
       <div className="max-w-2xl mx-auto">
-        <div className="rounded-2xl border border-red-200 bg-red-50 p-8 text-center text-red-600">
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-8 text-center text-red-600 dark:border-red-900/50 dark:bg-red-950/50 dark:text-red-300">
           {loadError || "Unable to load profile"}
         </div>
       </div>
@@ -147,10 +148,12 @@ export default function ProfilePage() {
 
   return (
     <div className="max-w-2xl mx-auto">
-      <div className="bg-white rounded-2xl border border-orange-100 shadow-sm">
-        <div className="border-b border-orange-100 px-8 py-6">
-          <h1 className="text-2xl font-bold text-gray-900">Profile</h1>
-          <p className="text-sm text-gray-500 mt-1">
+      <div className="bg-white dark:bg-dark-surface rounded-2xl border border-orange-100 dark:border-dark-border shadow-sm">
+        <div className="border-b border-orange-100 dark:border-dark-border px-8 py-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-dark-text-primary">
+            Profile
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-dark-text-secondary mt-1">
             Manage your account information and preferences
           </p>
         </div>
@@ -159,15 +162,19 @@ export default function ProfilePage() {
           <div className="flex items-center gap-4 mb-8">
             <Avatar name={user.name} src={user.avatarUrl} size="lg" />
             <div>
-              <h2 className="text-xl font-semibold text-gray-900">{user.name}</h2>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-dark-text-primary">
+                {user.name}
+              </h2>
               <div className="flex items-center gap-2 mt-1">
-                <span className="text-sm text-gray-500">{user.email}</span>
+                <span className="text-sm text-gray-500 dark:text-dark-text-secondary">
+                  {user.email}
+                </span>
                 <Badge
                   variant={isAdmin ? "primary" : "default"}
                   className={
                     isAdmin
-                      ? "bg-orange-100 text-orange-700"
-                      : "bg-gray-100 text-gray-700"
+                      ? "bg-orange-100 text-orange-700 dark:bg-orange-500/20 dark:text-orange-300"
+                      : "bg-gray-100 text-gray-700 dark:bg-dark-surface-hover dark:text-dark-text-secondary"
                   }
                 >
                   {isAdmin ? "Admin" : "User"}
@@ -178,12 +185,12 @@ export default function ProfilePage() {
 
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
             {error && (
-              <div className="rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-600">
+              <div className="rounded-xl bg-red-50 border border-red-200 p-3 text-sm text-red-600 dark:border-red-900/50 dark:bg-red-950/50 dark:text-red-300">
                 {error}
               </div>
             )}
             {success && (
-              <div className="rounded-xl bg-green-50 border border-green-200 p-3 text-sm text-green-700">
+              <div className="rounded-xl bg-green-50 border border-green-200 p-3 text-sm text-green-700 dark:border-green-900/50 dark:bg-green-950/50 dark:text-green-300">
                 {success}
               </div>
             )}
@@ -203,38 +210,44 @@ export default function ProfilePage() {
               {...register("avatarUrl")}
             />
 
-            <div className="grid grid-cols-2 gap-4 border-t border-orange-100 pt-6">
+            <div className="grid grid-cols-2 gap-4 border-t border-orange-100 dark:border-dark-border pt-6">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                <label className="block text-sm font-medium text-gray-700 dark:text-dark-text-secondary mb-1.5">
                   Email
                 </label>
-                <p className="text-sm text-gray-900">{user.email}</p>
-                <p className="text-xs text-gray-400 mt-0.5">Email cannot be changed</p>
+                <p className="text-sm text-gray-900 dark:text-dark-text-primary">
+                  {user.email}
+                </p>
+                <p className="text-xs text-gray-400 dark:text-dark-text-secondary mt-0.5">
+                  Email cannot be changed
+                </p>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                <label className="block text-sm font-medium text-gray-700 dark:text-dark-text-secondary mb-1.5">
                   Role
                 </label>
                 <Badge
                   className={
                     isAdmin
-                      ? "bg-orange-100 text-orange-700"
-                      : "bg-gray-100 text-gray-700"
+                      ? "bg-orange-100 text-orange-700 dark:bg-orange-500/20 dark:text-orange-300"
+                      : "bg-gray-100 text-gray-700 dark:bg-dark-surface-hover dark:text-dark-text-secondary"
                   }
                 >
                   {isAdmin ? "Admin" : "User"}
                 </Badge>
-                <p className="text-xs text-gray-400 mt-0.5">
+                <p className="text-xs text-gray-400 dark:text-dark-text-secondary mt-0.5">
                   {isAdmin
                     ? "Full access to project management"
                     : "Standard user access"}
                 </p>
               </div>
               <div className="col-span-2">
-                <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                <label className="block text-sm font-medium text-gray-700 dark:text-dark-text-secondary mb-1.5">
                   Member since
                 </label>
-                <p className="text-sm text-gray-900">{formatDate(user.createdAt)}</p>
+                <p className="text-sm text-gray-900 dark:text-dark-text-primary">
+                  {formatDate(user.createdAt)}
+                </p>
               </div>
             </div>
 
@@ -247,11 +260,28 @@ export default function ProfilePage() {
         </div>
       </div>
 
+      {/* Appearance / theme */}
+      <div className="bg-white dark:bg-dark-surface rounded-2xl border border-orange-100 dark:border-dark-border shadow-sm mt-6">
+        <div className="border-b border-orange-100 dark:border-dark-border px-8 py-6">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-dark-text-primary">
+            Appearance
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-dark-text-secondary mt-1">
+            Choose how LimeLight looks. System will follow your operating system.
+          </p>
+        </div>
+        <div className="p-8">
+          <ThemeToggle />
+        </div>
+      </div>
+
       {/* Change password */}
-      <div className="bg-white rounded-2xl border border-orange-100 shadow-sm mt-6">
-        <div className="border-b border-orange-100 px-8 py-6">
-          <h2 className="text-xl font-bold text-gray-900">Change Password</h2>
-          <p className="text-sm text-gray-500 mt-1">
+      <div className="bg-white dark:bg-dark-surface rounded-2xl border border-orange-100 dark:border-dark-border shadow-sm mt-6">
+        <div className="border-b border-orange-100 dark:border-dark-border px-8 py-6">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-dark-text-primary">
+            Change Password
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-dark-text-secondary mt-1">
             Use a strong password — at least 6 characters and different from your
             current one.
           </p>

--- a/src/app/api/users/me/preferences/route.ts
+++ b/src/app/api/users/me/preferences/route.ts
@@ -1,23 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
-import { getCurrentUserOrPATUser } from "@/lib/auth-pat";
 import { prisma } from "@/lib/prisma";
-import { updateProfileSchema } from "@/lib/validations";
-
-export async function GET(request: NextRequest) {
-  // Accepts either a session cookie or a PAT in the Authorization header.
-  const authResult = await getCurrentUserOrPATUser(request);
-
-  if (!authResult) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  return NextResponse.json({ user: authResult.user });
-}
+import { updateThemePreferenceSchema } from "@/lib/validations";
 
 export async function PATCH(request: NextRequest) {
-  // Profile updates remain session-only — we don't want a PAT to be able
-  // to change a user's display name or avatar URL.
   const currentUser = await getCurrentUser();
 
   if (!currentUser) {
@@ -25,7 +11,7 @@ export async function PATCH(request: NextRequest) {
   }
 
   const body = await request.json();
-  const validation = updateProfileSchema.safeParse(body);
+  const validation = updateThemePreferenceSchema.safeParse(body);
 
   if (!validation.success) {
     return NextResponse.json(
@@ -36,7 +22,7 @@ export async function PATCH(request: NextRequest) {
 
   const updated = await prisma.user.update({
     where: { id: currentUser.id },
-    data: validation.data,
+    data: { themePreference: validation.data.themePreference },
     select: {
       id: true,
       email: true,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,11 @@
   --foreground: #1C1917;
 }
 
+.dark {
+  --background: #0A0A0A;
+  --foreground: #FAFAFA;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
@@ -14,7 +19,7 @@ body {
 
 @layer base {
   * {
-    @apply border-border;
+    @apply border-border dark:border-dark-border;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
+import { ThemeProvider } from "@/components/theme/theme-provider";
+import { ThemeScript } from "@/components/theme/theme-script";
+import { getCurrentUser } from "@/lib/auth";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -10,15 +13,36 @@ export const metadata: Metadata = {
   description: "Illuminate your workflow with LimeLight task management",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Resolve the user's preference server-side so the no-flash inline
+  // script can apply the correct class before hydration. Falls back to
+  // SYSTEM for unauthenticated visitors or when the auth lookup fails
+  // (e.g. during a build where the database isn't reachable).
+  let initialPreference: "LIGHT" | "DARK" | "SYSTEM" = "SYSTEM";
+  try {
+    const user = await getCurrentUser();
+    if (user?.themePreference) {
+      initialPreference = user.themePreference;
+    }
+  } catch {
+    // Fall through with SYSTEM default.
+  }
+
   return (
-    <html lang="en" className="h-full">
-      <body className={`${inter.className} h-full bg-background text-text-primary antialiased`}>
-        <Providers>{children}</Providers>
+    <html lang="en" className="h-full" suppressHydrationWarning>
+      <head>
+        <ThemeScript serverPreference={initialPreference} />
+      </head>
+      <body
+        className={`${inter.className} h-full bg-background text-text-primary antialiased dark:bg-dark-background dark:text-dark-text-primary`}
+      >
+        <ThemeProvider initialPreference={initialPreference}>
+          <Providers>{children}</Providers>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/board/column.tsx
+++ b/src/components/board/column.tsx
@@ -19,13 +19,15 @@ export function Column({ status, tasks, onTaskClick, filtersActive = false }: Co
   return (
     <div
       ref={setNodeRef}
-      className={`w-72 flex-shrink-0 rounded-2xl bg-orange-50/50 p-4 ${
+      className={`w-72 flex-shrink-0 rounded-2xl bg-orange-50/50 p-4 dark:bg-dark-surface ${
         isOver ? "ring-2 ring-orange-400" : ""
       }`}
     >
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-gray-900">{status.name}</h3>
-        <span className="rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-medium text-orange-600">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-dark-text-primary">
+          {status.name}
+        </h3>
+        <span className="rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-medium text-orange-600 dark:bg-orange-500/20 dark:text-orange-300">
           {tasks.length}
         </span>
       </div>
@@ -39,7 +41,7 @@ export function Column({ status, tasks, onTaskClick, filtersActive = false }: Co
       </SortableContext>
 
       {tasks.length === 0 && (
-        <div className="rounded-xl border-2 border-dashed border-orange-200 p-4 text-center text-sm text-gray-400">
+        <div className="rounded-xl border-2 border-dashed border-orange-200 p-4 text-center text-sm text-gray-400 dark:border-dark-border dark:text-dark-text-secondary">
           {filtersActive ? "No tasks match your filters" : "Drop tasks here"}
         </div>
       )}

--- a/src/components/board/task-card.tsx
+++ b/src/components/board/task-card.tsx
@@ -30,12 +30,12 @@ export function TaskCard({ task, isDragging, onClick }: TaskCardProps) {
       {...listeners}
       onClick={onClick}
       className={cn(
-        "cursor-pointer rounded-xl border border-orange-100 bg-white p-4 shadow-sm transition-all hover:shadow-md hover:border-orange-200",
+        "cursor-pointer rounded-xl border border-orange-100 bg-white p-4 shadow-sm transition-all hover:shadow-md hover:border-orange-200 dark:border-dark-border dark:bg-dark-surface-hover dark:hover:border-orange-500/40",
         isDragging && "opacity-50 shadow-lg"
       )}
     >
-      <p className="text-xs text-orange-500 font-medium">{task.key}</p>
-      <h4 className="mt-1 text-sm font-medium text-gray-900 line-clamp-2">
+      <p className="text-xs text-orange-500 font-medium dark:text-orange-400">{task.key}</p>
+      <h4 className="mt-1 text-sm font-medium text-gray-900 line-clamp-2 dark:text-dark-text-primary">
         {task.title}
       </h4>
 

--- a/src/components/projects/header.tsx
+++ b/src/components/projects/header.tsx
@@ -23,14 +23,14 @@ export function Header({ user }: HeaderProps) {
   const isAdmin = user.role === "ADMIN";
 
   return (
-    <header className="flex h-16 items-center justify-between border-b border-orange-100 bg-white px-6">
+    <header className="flex h-16 items-center justify-between border-b border-orange-100 bg-white px-6 dark:border-dark-border dark:bg-dark-surface">
       <div className="md:hidden flex items-center gap-2">
         <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center">
           <svg className="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
           </svg>
         </div>
-        <span className="text-xl font-bold bg-gradient-to-r from-orange-600 to-amber-600 bg-clip-text text-transparent">
+        <span className="text-xl font-bold bg-gradient-to-r from-orange-600 to-amber-600 bg-clip-text text-transparent dark:from-orange-400 dark:to-amber-400">
           LimeLight
         </span>
       </div>
@@ -38,46 +38,54 @@ export function Header({ user }: HeaderProps) {
       <div className="relative">
         <button
           onClick={() => setIsMenuOpen(!isMenuOpen)}
-          className="flex items-center gap-2 rounded-lg p-2 hover:bg-orange-50 transition-colors"
+          className="flex items-center gap-2 rounded-lg p-2 hover:bg-orange-50 transition-colors dark:hover:bg-dark-surface-hover"
         >
           <Avatar name={user.name} src={user.avatarUrl} size="sm" />
           <div className="hidden md:flex md:flex-col md:items-start md:gap-0.5">
-            <span className="text-sm font-medium text-gray-700">{user.name}</span>
+            <span className="text-sm font-medium text-gray-700 dark:text-dark-text-primary">
+              {user.name}
+            </span>
             <span
               className={`text-xs font-medium ${
-                isAdmin ? "text-orange-600" : "text-gray-400"
+                isAdmin
+                  ? "text-orange-600 dark:text-orange-400"
+                  : "text-gray-400 dark:text-dark-text-secondary"
               }`}
             >
               {isAdmin ? "Admin" : "User"}
             </span>
           </div>
-          <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="h-4 w-4 text-gray-400 dark:text-dark-text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
           </svg>
         </button>
         {isMenuOpen && (
           <>
             <div className="fixed inset-0 z-10" onClick={() => setIsMenuOpen(false)} />
-            <div className="absolute right-0 z-20 mt-2 w-64 rounded-xl border border-orange-100 bg-white py-1 shadow-lg">
-              <div className="border-b border-orange-100 px-4 py-3">
+            <div className="absolute right-0 z-20 mt-2 w-64 rounded-xl border border-orange-100 bg-white py-1 shadow-lg dark:border-dark-border dark:bg-dark-surface">
+              <div className="border-b border-orange-100 px-4 py-3 dark:border-dark-border">
                 <div className="flex items-center justify-between gap-2">
-                  <p className="text-sm font-medium text-gray-900 truncate">{user.name}</p>
+                  <p className="text-sm font-medium text-gray-900 truncate dark:text-dark-text-primary">
+                    {user.name}
+                  </p>
                   <span
                     className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
                       isAdmin
-                        ? "bg-orange-100 text-orange-700"
-                        : "bg-gray-100 text-gray-600"
+                        ? "bg-orange-100 text-orange-700 dark:bg-orange-500/20 dark:text-orange-300"
+                        : "bg-gray-100 text-gray-600 dark:bg-dark-surface-hover dark:text-dark-text-secondary"
                     }`}
                   >
                     {isAdmin ? "Admin" : "User"}
                   </span>
                 </div>
-                <p className="text-xs text-gray-500 truncate mt-1">{user.email}</p>
+                <p className="text-xs text-gray-500 truncate mt-1 dark:text-dark-text-secondary">
+                  {user.email}
+                </p>
               </div>
               <Link
                 href="/profile"
                 onClick={() => setIsMenuOpen(false)}
-                className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-600 hover:bg-orange-50 transition-colors"
+                className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-600 hover:bg-orange-50 transition-colors dark:text-dark-text-secondary dark:hover:bg-dark-surface-hover"
               >
                 <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
@@ -86,7 +94,7 @@ export function Header({ user }: HeaderProps) {
               </Link>
               <button
                 onClick={handleLogout}
-                className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-600 hover:bg-orange-50 transition-colors"
+                className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-gray-600 hover:bg-orange-50 transition-colors dark:text-dark-text-secondary dark:hover:bg-dark-surface-hover"
               >
                 <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />

--- a/src/components/projects/sidebar.tsx
+++ b/src/components/projects/sidebar.tsx
@@ -13,19 +13,19 @@ export function Sidebar({ user: _user }: SidebarProps) {
   const pathname = usePathname();
 
   return (
-    <aside className="hidden w-64 flex-shrink-0 border-r border-orange-100 bg-white md:block">
-      <div className="flex h-16 items-center gap-3 border-b border-orange-100 px-6">
+    <aside className="hidden w-64 flex-shrink-0 border-r border-orange-100 bg-white md:block dark:border-dark-border dark:bg-dark-surface">
+      <div className="flex h-16 items-center gap-3 border-b border-orange-100 px-6 dark:border-dark-border">
         <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center">
           <svg className="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
           </svg>
         </div>
-        <Link href="/projects" className="text-xl font-bold bg-gradient-to-r from-orange-600 to-amber-600 bg-clip-text text-transparent">
+        <Link href="/projects" className="text-xl font-bold bg-gradient-to-r from-orange-600 to-amber-600 bg-clip-text text-transparent dark:from-orange-400 dark:to-amber-400">
           LimeLight
         </Link>
       </div>
       <nav className="p-4">
-        <div className="mb-3 px-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+        <div className="mb-3 px-3 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-dark-text-secondary">
           Navigation
         </div>
         <Link
@@ -33,8 +33,8 @@ export function Sidebar({ user: _user }: SidebarProps) {
           className={cn(
             "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors",
             pathname === "/projects" || pathname.startsWith("/projects/")
-              ? "bg-orange-50 text-orange-600"
-              : "text-gray-600 hover:bg-gray-50"
+              ? "bg-orange-50 text-orange-600 dark:bg-orange-500/10 dark:text-orange-300"
+              : "text-gray-600 hover:bg-gray-50 dark:text-dark-text-secondary dark:hover:bg-dark-surface-hover"
           )}
         >
           <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/theme/theme-provider.tsx
+++ b/src/components/theme/theme-provider.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type ThemePreference = "LIGHT" | "DARK" | "SYSTEM";
+export type ResolvedTheme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "limelight-theme";
+
+/**
+ * Resolve a `ThemePreference` against the current system color-scheme to a
+ * concrete light / dark theme.
+ */
+export function resolveTheme(
+  preference: ThemePreference,
+  systemPrefersDark: boolean
+): ResolvedTheme {
+  if (preference === "DARK") return "dark";
+  if (preference === "LIGHT") return "light";
+  return systemPrefersDark ? "dark" : "light";
+}
+
+interface ThemeContextValue {
+  themePreference: ThemePreference;
+  resolvedTheme: ResolvedTheme;
+  setThemePreference: (preference: ThemePreference) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return ctx;
+}
+
+interface ThemeProviderProps {
+  children: ReactNode;
+  /** Preference seeded from the server (or storage). Defaults to SYSTEM. */
+  initialPreference?: ThemePreference;
+  /**
+   * When true (the default), changes to the preference are persisted to
+   * `/api/auth/me`. Set to false to skip the network call (useful in tests
+   * or for unauthenticated pages).
+   */
+  persistOnChange?: boolean;
+}
+
+function applyThemeClass(theme: ResolvedTheme) {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (theme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+  // Also expose the resolved theme for native form-control color schemes.
+  root.style.colorScheme = theme;
+}
+
+function getSystemPrefersDark(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+export function ThemeProvider({
+  children,
+  initialPreference = "SYSTEM",
+  persistOnChange = true,
+}: ThemeProviderProps) {
+  const [themePreference, setThemePreferenceState] =
+    useState<ThemePreference>(initialPreference);
+  const [systemPrefersDark, setSystemPrefersDark] = useState<boolean>(() =>
+    getSystemPrefersDark()
+  );
+
+  // Track which preference value we've already persisted so we don't fire a
+  // PATCH for the initial value seeded from the server.
+  const lastPersistedRef = useRef<ThemePreference>(initialPreference);
+
+  // Watch the system preference; update only matters when preference is SYSTEM.
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = (e: MediaQueryListEvent | { matches: boolean }) => {
+      setSystemPrefersDark(e.matches);
+    };
+    // Modern API
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    // Legacy fallback (Safari < 14)
+    type LegacyMql = MediaQueryList & {
+      addListener: (cb: (e: MediaQueryListEvent) => void) => void;
+      removeListener: (cb: (e: MediaQueryListEvent) => void) => void;
+    };
+    const legacy = mql as LegacyMql;
+    legacy.addListener(onChange);
+    return () => legacy.removeListener(onChange);
+  }, []);
+
+  const resolvedTheme = useMemo(
+    () => resolveTheme(themePreference, systemPrefersDark),
+    [themePreference, systemPrefersDark]
+  );
+
+  // Apply the class to <html> any time the resolved theme changes.
+  useEffect(() => {
+    applyThemeClass(resolvedTheme);
+  }, [resolvedTheme]);
+
+  const setThemePreference = useCallback(
+    (preference: ThemePreference) => {
+      setThemePreferenceState(preference);
+      // Mirror to localStorage as a defensive cache for the no-flash script.
+      try {
+        if (typeof window !== "undefined" && window.localStorage) {
+          window.localStorage.setItem(THEME_STORAGE_KEY, preference);
+        }
+      } catch {
+        // Storage may be unavailable (private mode, quota); ignore.
+      }
+      if (
+        persistOnChange &&
+        typeof fetch === "function" &&
+        lastPersistedRef.current !== preference
+      ) {
+        lastPersistedRef.current = preference;
+        // Fire-and-forget; failures are non-fatal — the user's local
+        // preference still applies for this session.
+        try {
+          const result = fetch("/api/users/me/preferences", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ themePreference: preference }),
+          });
+          if (result && typeof (result as Promise<unknown>).catch === "function") {
+            (result as Promise<unknown>).catch(() => {
+              /* swallow — non-fatal */
+            });
+          }
+        } catch {
+          /* swallow — non-fatal */
+        }
+      }
+    },
+    [persistOnChange]
+  );
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ themePreference, resolvedTheme, setThemePreference }),
+    [themePreference, resolvedTheme, setThemePreference]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}

--- a/src/components/theme/theme-script.tsx
+++ b/src/components/theme/theme-script.tsx
@@ -1,0 +1,53 @@
+/**
+ * Inline script injected into the <head> to set the `dark` class on
+ * <html> *before* React hydrates. This prevents a flash of the wrong
+ * theme on initial page load.
+ *
+ * Order of preference:
+ *   1. The server-rendered preference (passed in via `serverPreference`)
+ *   2. Cached preference in localStorage (for unauthenticated users)
+ *   3. The system color-scheme via `prefers-color-scheme`
+ */
+import { THEME_STORAGE_KEY, type ThemePreference } from "./theme-provider";
+
+interface ThemeScriptProps {
+  serverPreference?: ThemePreference | null;
+}
+
+export function ThemeScript({ serverPreference }: ThemeScriptProps) {
+  const safe = serverPreference ?? null;
+  // The script body is intentionally compact and dependency-free. It must
+  // run synchronously in the document <head> for no-flash behaviour.
+  const code = `
+(function() {
+  try {
+    var key = ${JSON.stringify(THEME_STORAGE_KEY)};
+    var serverPref = ${JSON.stringify(safe)};
+    var stored = null;
+    try { stored = window.localStorage.getItem(key); } catch (e) {}
+    var pref = serverPref || stored || 'SYSTEM';
+    var resolved;
+    if (pref === 'DARK') {
+      resolved = 'dark';
+    } else if (pref === 'LIGHT') {
+      resolved = 'light';
+    } else {
+      resolved = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    var root = document.documentElement;
+    if (resolved === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    root.style.colorScheme = resolved;
+  } catch (e) {}
+})();`;
+
+  return (
+    <script
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: code }}
+    />
+  );
+}

--- a/src/components/theme/theme-toggle.tsx
+++ b/src/components/theme/theme-toggle.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useTheme, type ThemePreference } from "./theme-provider";
+
+const OPTIONS: { value: ThemePreference; label: string; description: string }[] =
+  [
+    { value: "LIGHT", label: "Light", description: "Always light" },
+    { value: "DARK", label: "Dark", description: "Always dark" },
+    {
+      value: "SYSTEM",
+      label: "System",
+      description: "Follow your OS preference",
+    },
+  ];
+
+interface ThemeToggleProps {
+  /** Optional id used to label the radiogroup for accessibility. */
+  id?: string;
+}
+
+/**
+ * Light / Dark / System theme picker. Renders as a radiogroup so it remains
+ * keyboard-accessible.
+ */
+export function ThemeToggle({ id = "theme-toggle" }: ThemeToggleProps) {
+  const { themePreference, setThemePreference } = useTheme();
+
+  return (
+    <div role="radiogroup" aria-labelledby={`${id}-label`} className="space-y-2">
+      <span id={`${id}-label`} className="sr-only">
+        Theme preference
+      </span>
+      <div className="inline-flex gap-1 rounded-xl border border-orange-100 bg-white p-1 dark:border-dark-border dark:bg-dark-surface">
+        {OPTIONS.map((option) => {
+          const selected = themePreference === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={option.label}
+              title={option.description}
+              onClick={() => setThemePreference(option.value)}
+              className={
+                "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors " +
+                (selected
+                  ? "bg-orange-500 text-white shadow-sm"
+                  : "text-gray-600 hover:bg-orange-50 dark:text-dark-text-secondary dark:hover:bg-dark-surface-hover")
+              }
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -67,6 +67,7 @@ export async function getCurrentUser() {
       name: true,
       avatarUrl: true,
       role: true,
+      themePreference: true,
       createdAt: true,
     },
   });

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -72,6 +72,10 @@ export const updateMemberSchema = z.object({
   }),
 });
 
+// Theme preference values — must mirror the Prisma `ThemePreference` enum.
+export const THEME_PREFERENCES = ["LIGHT", "DARK", "SYSTEM"] as const;
+export type ThemePreferenceInput = (typeof THEME_PREFERENCES)[number];
+
 // Profile validations
 export const updateProfileSchema = z
   .object({
@@ -85,6 +89,23 @@ export const updateProfileSchema = z
       .or(z.literal(""))
       .optional()
       .nullable(),
+    themePreference: z
+      .enum(THEME_PREFERENCES, {
+        errorMap: () => ({
+          message: "Theme preference must be LIGHT, DARK, or SYSTEM",
+        }),
+      })
+      .optional(),
+  })
+  .strip();
+
+export const updateThemePreferenceSchema = z
+  .object({
+    themePreference: z.enum(THEME_PREFERENCES, {
+      errorMap: () => ({
+        message: "Theme preference must be LIGHT, DARK, or SYSTEM",
+      }),
+    }),
   })
   .strip();
 
@@ -185,6 +206,7 @@ export type UpdateStatusInput = z.infer<typeof updateStatusSchema>;
 export type AddMemberInput = z.infer<typeof addMemberSchema>;
 export type UpdateMemberInput = z.infer<typeof updateMemberSchema>;
 export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
+export type UpdateThemePreferenceInput = z.infer<typeof updateThemePreferenceSchema>;
 export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
 export type CreateVulnerabilityInput = z.infer<typeof createVulnerabilitySchema>;
 export type UpdateVulnerabilityInput = z.infer<typeof updateVulnerabilitySchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,12 +2,21 @@ import {
   Priority,
   Role,
   SystemRole,
+  ThemePreference,
   VulnSeverity,
   VulnStatus,
   ExploitStatus,
 } from "@prisma/client";
 
-export type { Priority, Role, SystemRole, VulnSeverity, VulnStatus, ExploitStatus };
+export type {
+  Priority,
+  Role,
+  SystemRole,
+  ThemePreference,
+  VulnSeverity,
+  VulnStatus,
+  ExploitStatus,
+};
 
 export interface User {
   id: string;
@@ -15,6 +24,12 @@ export interface User {
   name: string;
   avatarUrl: string | null;
   role: SystemRole;
+  /**
+   * Optional because not every Prisma `select` includes this column —
+   * components that need it (the theme provider, profile page) read it
+   * from the auth-aware API which always selects it. Defaults to SYSTEM.
+   */
+  themePreference?: ThemePreference;
   createdAt: Date;
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,10 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  // Class-based dark mode: applied by toggling `class="dark"` on <html>
+  // (handled by ThemeProvider). The orange primary palette stays vibrant in
+  // both modes; surfaces and text shift to neutral-900 / neutral-100 in dark.
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -26,20 +30,45 @@ const config: Config = {
         success: {
           DEFAULT: "#22C55E",
           light: "#DCFCE7",
+          // Slightly desaturated for dark surfaces
+          dark: "#16A34A",
         },
         warning: {
           DEFAULT: "#EAB308",
           light: "#FEF9C3",
+          dark: "#CA8A04",
         },
         danger: {
           DEFAULT: "#EF4444",
           light: "#FEE2E2",
+          dark: "#DC2626",
         },
+        // Light-mode tokens (existing behaviour preserved)
         background: "#FFFBF5",
         surface: "#FFFFFF",
         border: "#FED7AA",
         "text-primary": "#1C1917",
         "text-secondary": "#78716C",
+        // Dark-mode tokens — used via the `dark:` variant
+        "dark-background": "#0A0A0A",
+        "dark-surface": "#171717",
+        "dark-surface-hover": "#262626",
+        "dark-border": "#404040",
+        "dark-text-primary": "#FAFAFA",
+        "dark-text-secondary": "#A3A3A3",
+        // Status colors tuned for dark mode (todo/in-progress/done)
+        "status-todo": {
+          light: "#E5E7EB",
+          dark: "#374151",
+        },
+        "status-in-progress": {
+          light: "#DBEAFE",
+          dark: "#1E3A8A",
+        },
+        "status-done": {
+          light: "#DCFCE7",
+          dark: "#14532D",
+        },
       },
       fontFamily: {
         sans: [


### PR DESCRIPTION
## Summary

Adds Light / Dark / System dark-theme support for LimeLight, persisted on
the user record (issue #1).

- **Schema:** new `ThemePreference` enum (`LIGHT | DARK | SYSTEM`, default
  `SYSTEM`) on `User`. Migration runs at PR-merge time.
- **API:** dedicated `PATCH /api/users/me/preferences` endpoint, plus
  optional `themePreference` field in the existing `PATCH /api/auth/me`
  schema.
- **Theme provider:** wraps the app at the root layout; reads the
  server-resolved preference, applies `class="dark"` to `<html>`, follows
  `prefers-color-scheme` when `SYSTEM`, and PATCHes the preferences API
  on change. An inline `ThemeScript` in the document `<head>` avoids a
  flash of the wrong theme on initial paint.
- **Tailwind:** `darkMode: 'class'`, plus dark surface / border / text
  tokens that complement the existing orange primary. Status (todo /
  in-progress / done) colors remain distinguishable in dark mode.
- **UI:** `ThemeToggle` (Light / Dark / System) added to the Profile
  page as an accessible radiogroup. Dark variants applied to the
  dashboard chrome (sidebar, header, profile page) and the board (task
  cards, columns).

## Design choices

- **Enum vs. string:** Prisma enum so the database schema enforces the
  three valid values; mirrored as a Zod enum and TypeScript union.
- **Dedicated endpoint vs. extending `/api/auth/me`:** added the
  dedicated `/api/users/me/preferences` route so theme toggles don't
  need to satisfy the profile-update schema (which still requires
  `name`). The `auth/me` schema also accepts `themePreference` for
  callers that want to update everything together.
- **Provider lives at root layout** so the theme is applied on every
  page (auth pages too); the no-flash inline script runs before
  hydration and reads the server-resolved preference.
- **`User.themePreference` typed as optional** — Prisma queries that
  don't `select` it will not have the field populated. The auth helper
  always selects it.

## Test plan

- [x] `npm test` — 252 tests passing across 22 suites (added 46 new
      tests covering validation, both API routes, theme resolution,
      system-preference reactivity, persistence, toggle UX, and
      dark-variant rendering on the board)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — exits 0 (warnings only, all pre-existing or in
      type-only positions)
- [x] `npm run build` — production build succeeds, all 17 routes
      generated, including the new `/api/users/me/preferences`
- [ ] Smoke test in dev: toggle Light/Dark/System on the Profile page,
      reload, confirm preference persists and no flash on initial paint
- [ ] Verify `prefers-color-scheme` reactivity by changing macOS
      appearance while set to SYSTEM

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)