### PR TITLE
test: add smoke tests for deployed API

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,50 @@
+name: Smoke tests (deployed API)
+
+# Catches issues local CI can't: schema-not-synced after deploy, missing
+# env vars, broken Vercel deploys, runtime auth failures.
+
+on:
+  schedule:
+    # Every hour on the hour. Adjust if it gets noisy.
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Base URL to smoke-test (defaults to production)"
+        required: false
+        default: "https://limelightv1.vercel.app"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke-${{ github.event.inputs.base_url || 'production' }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Smoke ${{ github.event.inputs.base_url || 'https://limelightv1.vercel.app' }}
+    runs-on: ubuntu-latest
+    env:
+      SMOKE_BASE_URL: ${{ github.event.inputs.base_url || 'https://limelightv1.vercel.app' }}
+      # postinstall runs `prisma generate` which only needs DATABASE_URL to
+      # be defined — it never connects. Smoke tests themselves use SMOKE_BASE_URL.
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/limelight_ci
+      DATABASE_URL_UNPOOLED: postgresql://postgres:postgres@localhost:5432/limelight_ci
+      JWT_SECRET: ci-secret-not-used-anywhere
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run smoke tests
+        run: npm run test:smoke

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ next-env.d.ts
 
 # local npm cache (only created when HOME is set into the worktree)
 .npm/
+
+# Local agent worktrees
+.claude/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ After seeding the database, you can log in with:
 | `npm test` | Run tests |
 | `npm run test:watch` | Run tests in watch mode |
 | `npm run test:coverage` | Run tests with coverage report |
+| `npm run test:smoke` | Smoke-test the deployed API (set `SMOKE_BASE_URL`) |
 | `npm run db:generate` | Generate Prisma client |
 | `npm run db:push` | Push schema to database |
 | `npm run db:migrate` | Run database migrations |
@@ -154,6 +155,29 @@ A coverage summary is posted as a PR comment on every push and updated in
 place by the
 [MishaKav/jest-coverage-comment](https://github.com/MishaKav/jest-coverage-comment)
 action.
+
+### Smoke tests against the deployed API
+
+Local unit and component tests use mocked fetches and a mocked Prisma client.
+That can mask real-world deploy issues — schema drift after a merge, missing
+env vars on Vercel, broken build artifacts — that only surface against the
+live HTTPS endpoints.
+
+`npm run test:smoke` exercises the deployed API end-to-end: registers a
+fresh user, signs in, mints a personal access token, uses it, revokes it,
+and confirms revocation takes effect. It also verifies `/api/version`
+returns the expected shape and that unauthenticated requests are rejected.
+
+Tests live in `src/__smoke__/` and are skipped from `npm test` and the
+coverage gate by configuration. Override the target deployment with:
+
+```bash
+SMOKE_BASE_URL=https://staging.example.vercel.app npm run test:smoke
+```
+
+A GitHub Actions workflow (`.github/workflows/smoke.yml`) runs the suite
+hourly against production and is also available via `workflow_dispatch`
+for ad-hoc post-deploy checks.
 
 ### Test Structure
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,10 +14,21 @@ const customJestConfig = {
     "**/__tests__/**/*.[jt]s?(x)",
     "**/?(*.)+(spec|test).[jt]s?(x)",
   ],
+  // Smoke tests hit a real deployed environment over HTTPS — they don't
+  // belong in the default `npm test` run. Use `npm run test:smoke` instead.
+  // `.claude/worktrees/` holds isolated git worktrees used by background
+  // agents — their test files are not part of this checkout.
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    "<rootDir>/src/__smoke__/",
+    "<rootDir>/.claude/",
+  ],
   collectCoverageFrom: [
     "src/**/*.{js,jsx,ts,tsx}",
     // Exclude test files themselves from coverage stats
     "!src/__tests__/**",
+    // Smoke tests run against the deployed API, not the local code
+    "!src/__smoke__/**",
     // Exclude config files (tooling configuration, not app code)
     "!**/*.config.{ts,js}",
     // Exclude TypeScript declaration-only files

--- a/jest.smoke.config.js
+++ b/jest.smoke.config.js
@@ -1,0 +1,21 @@
+/**
+ * Jest config for smoke tests that hit the deployed HTTPS API.
+ *
+ * Run via `npm run test:smoke`. Set SMOKE_BASE_URL to point at a
+ * different deployment.
+ */
+const nextJest = require("next/jest");
+
+const createJestConfig = nextJest({ dir: "./" });
+
+module.exports = createJestConfig({
+  testEnvironment: "node",
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  testMatch: ["<rootDir>/src/__smoke__/**/*.smoke.test.[jt]s?(x)"],
+  testPathIgnorePatterns: ["/node_modules/", "<rootDir>/.claude/"],
+  // Disable coverage thresholds — smoke tests don't reflect code coverage.
+  collectCoverage: false,
+  // No setup file — smoke tests don't mock anything.
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "test:smoke": "jest --config=jest.smoke.config.js",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",

--- a/src/__smoke__/api.smoke.test.ts
+++ b/src/__smoke__/api.smoke.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment node
+ *
+ * Smoke tests that hit the deployed HTTPS API to catch issues local tests
+ * can't: schema-not-synced after deploy, missing env vars, broken Vercel
+ * deploys, runtime auth failures.
+ *
+ * Run with `npm run test:smoke`. Skipped by default in `npm test`.
+ *
+ * Configurable via env:
+ *   SMOKE_BASE_URL — defaults to https://limelightv1.vercel.app
+ *
+ * Each run registers a fresh user with a unique email, so tests don't
+ * depend on rotated seed credentials. The registered user will remain on
+ * the system after the run — tolerated for now; can be cleaned up by a
+ * future "delete account" endpoint.
+ */
+
+const BASE_URL = (process.env.SMOKE_BASE_URL ?? "https://limelightv1.vercel.app").replace(
+  /\/$/,
+  ""
+);
+
+// Per-run unique credentials so back-to-back runs don't collide.
+const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const TEST_USER = {
+  email: `smoke-${uniqueId}@smoke.test`,
+  password: `smoke-pw-${uniqueId}`,
+  name: `Smoke ${uniqueId}`,
+};
+
+/**
+ * Pull the auth-token cookie out of a Set-Cookie response header so we can
+ * replay it on subsequent requests. Cookie jar would be overkill — we only
+ * care about a single named cookie.
+ */
+function extractAuthCookie(response: Response): string | null {
+  // Some runtimes expose getSetCookie(); fall back to the raw header.
+  const cookies = (response.headers as Headers & { getSetCookie?: () => string[] })
+    .getSetCookie?.() ?? [response.headers.get("set-cookie") ?? ""];
+  for (const c of cookies) {
+    const match = c.match(/auth-token=([^;]+)/);
+    if (match) return `auth-token=${match[1]}`;
+  }
+  return null;
+}
+
+// State carried across the ordered test sequence. Each test is independent
+// in what it asserts but they share an in-memory session.
+const session: {
+  cookie: string | null;
+  rawToken: string | null;
+  tokenId: string | null;
+} = {
+  cookie: null,
+  rawToken: null,
+  tokenId: null,
+};
+
+describe(`smoke: deployed API at ${BASE_URL}`, () => {
+  // Generous because cold starts on serverless can be slow.
+  jest.setTimeout(30_000);
+
+  it("GET /api/version returns version metadata", async () => {
+    const res = await fetch(`${BASE_URL}/api/version`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.version).toBe("string");
+    expect(body.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(typeof body.commit).toBe("string");
+    expect(typeof body.builtAt).toBe("string");
+    // builtAt should be a valid ISO timestamp
+    expect(Number.isFinite(Date.parse(body.builtAt))).toBe(true);
+  });
+
+  it("GET /api/auth/me without a session returns 401", async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/me`);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toHaveProperty("error");
+  });
+
+  it("POST /api/auth/login with bogus credentials returns 401", async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "nobody@example.invalid",
+        password: "definitely-wrong-password",
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/auth/register creates a fresh user and sets a session cookie", async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(TEST_USER),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.email).toBe(TEST_USER.email);
+
+    const cookie = extractAuthCookie(res);
+    expect(cookie).not.toBeNull();
+    session.cookie = cookie;
+  });
+
+  it("POST /api/auth/login with the registered credentials returns a session", async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: TEST_USER.email,
+        password: TEST_USER.password,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const cookie = extractAuthCookie(res);
+    expect(cookie).not.toBeNull();
+    // Prefer the freshest cookie for subsequent requests.
+    session.cookie = cookie;
+  });
+
+  it("GET /api/auth/me with the session cookie returns the user", async () => {
+    expect(session.cookie).toBeTruthy();
+    const res = await fetch(`${BASE_URL}/api/auth/me`, {
+      headers: { Cookie: session.cookie! },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.email).toBe(TEST_USER.email);
+  });
+
+  it("POST /api/users/me/tokens creates a personal access token", async () => {
+    expect(session.cookie).toBeTruthy();
+    const res = await fetch(`${BASE_URL}/api/users/me/tokens`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: session.cookie!,
+      },
+      body: JSON.stringify({ name: "smoke-test-token" }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(typeof body.token).toBe("string");
+    expect(body.token).toMatch(/^ll_pat_/);
+    expect(body.personalAccessToken).toBeTruthy();
+    expect(typeof body.personalAccessToken.id).toBe("string");
+    session.rawToken = body.token;
+    session.tokenId = body.personalAccessToken.id;
+  });
+
+  it("GET /api/auth/me with the PAT in Authorization header returns the user", async () => {
+    expect(session.rawToken).toBeTruthy();
+    const res = await fetch(`${BASE_URL}/api/auth/me`, {
+      headers: { Authorization: `Bearer ${session.rawToken!}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.email).toBe(TEST_USER.email);
+  });
+
+  it("GET /api/auth/me with a malformed Bearer token returns 401", async () => {
+    const res = await fetch(`${BASE_URL}/api/auth/me`, {
+      headers: { Authorization: "Bearer ll_pat_not-a-real-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/users/me/tokens lists the created token without exposing the raw value", async () => {
+    expect(session.cookie).toBeTruthy();
+    const res = await fetch(`${BASE_URL}/api/users/me/tokens`, {
+      headers: { Cookie: session.cookie! },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.personalAccessTokens)).toBe(true);
+    const created = body.personalAccessTokens.find(
+      (t: { id: string }) => t.id === session.tokenId
+    );
+    expect(created).toBeTruthy();
+    expect(created).not.toHaveProperty("token");
+    expect(created).not.toHaveProperty("tokenHash");
+  });
+
+  it("DELETE /api/users/me/tokens/:id revokes the PAT", async () => {
+    expect(session.cookie).toBeTruthy();
+    expect(session.tokenId).toBeTruthy();
+    const res = await fetch(`${BASE_URL}/api/users/me/tokens/${session.tokenId}`, {
+      method: "DELETE",
+      headers: { Cookie: session.cookie! },
+    });
+    expect([200, 204]).toContain(res.status);
+  });
+
+  it("GET /api/auth/me with the now-revoked PAT returns 401", async () => {
+    expect(session.rawToken).toBeTruthy();
+    const res = await fetch(`${BASE_URL}/api/auth/me`, {
+      headers: { Authorization: `Bearer ${session.rawToken!}` },
+    });
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
End-to-end smoke tests that hit the live HTTPS API to catch issues local CI can't:
- Schema drift after a merge (e.g. PAT rollout where every local test was green but prod 500'd because the table didn't exist on Neon yet)
- Missing env vars on Vercel
- Broken build artifacts
- Runtime auth failures

## What it covers
12 ordered tests against the deployed API:
- `/api/version` shape
- Unauthenticated `/api/auth/me` → 401
- Bad-creds login → 401
- Register fresh per-run user → 200 + cookie
- Login → 200 + cookie
- Cookie-authed `/api/auth/me` → 200
- Create PAT → 201 with `ll_pat_…` token
- Bearer-authed `/api/auth/me` → 200
- Garbage Bearer token → 401
- List PATs (no raw values exposed)
- Revoke PAT
- Bearer with revoked PAT → 401

## How to run
```bash
npm run test:smoke                                              # production
SMOKE_BASE_URL=https://staging.example.vercel.app npm run test:smoke
```

## Wiring
- `src/__smoke__/api.smoke.test.ts` — suite
- `jest.smoke.config.js` — separate config (node env, no coverage threshold)
- `npm run test:smoke` script
- `.github/workflows/smoke.yml` — hourly schedule + manual dispatch with optional `base_url` input
- `jest.config.js` — ignores `src/__smoke__` and `.claude/` worktrees

## Test plan
- [x] `npm run test:smoke` against production passed locally (12/12)
- [x] `npm test` still passes (254/254) — smoke suite excluded
- [x] `npm run test:coverage` clears the 35% gate
- [x] `npm run build` succeeds
- [ ] Workflow runs cleanly on its first scheduled fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)