### PR TITLE
chore: hide demo credentials banner outside development

### DIFF
--- a/src/__tests__/api/tasks-filtering.test.ts
+++ b/src/__tests__/api/tasks-filtering.test.ts
@@ -34,6 +34,7 @@ const me = {
   name: "Me",
   avatarUrl: null,
   role: "USER" as const,
+  themePreference: "SYSTEM" as const,
   createdAt: new Date("2024-01-01"),
 };
 

--- a/src/__tests__/components/LoginPage.test.tsx
+++ b/src/__tests__/components/LoginPage.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import LoginPage from "@/app/(auth)/login/page";
+
+jest.mock("@/components/ui", () => {
+  const React = require("react");
+  return {
+    Button: React.forwardRef(
+      (
+        {
+          children,
+          isLoading,
+          ...props
+        }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+          children: React.ReactNode;
+          isLoading?: boolean;
+        },
+        ref: React.Ref<HTMLButtonElement>
+      ) => (
+        <button ref={ref} {...props}>
+          {isLoading ? "Loading..." : children}
+        </button>
+      )
+    ),
+    Input: React.forwardRef(
+      (
+        {
+          label,
+          error,
+          ...props
+        }: { label?: string; error?: string } & React.InputHTMLAttributes<HTMLInputElement>,
+        ref: React.Ref<HTMLInputElement>
+      ) => (
+        <div>
+          {label && <label htmlFor={props.id}>{label}</label>}
+          <input ref={ref} {...props} />
+        </div>
+      )
+    ),
+  };
+});
+
+describe("LoginPage demo credentials banner", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    Object.defineProperty(process.env, "NODE_ENV", {
+      value: originalNodeEnv,
+      configurable: true,
+    });
+  });
+
+  function setNodeEnv(value: string) {
+    Object.defineProperty(process.env, "NODE_ENV", {
+      value,
+      configurable: true,
+    });
+  }
+
+  it("shows the demo credentials banner in development", () => {
+    setNodeEnv("development");
+    render(<LoginPage />);
+    expect(screen.getByText(/demo@example\.com/)).toBeInTheDocument();
+    expect(screen.getByText(/password123/)).toBeInTheDocument();
+  });
+
+  it("shows the demo credentials banner in test", () => {
+    setNodeEnv("test");
+    render(<LoginPage />);
+    expect(screen.getByText(/demo@example\.com/)).toBeInTheDocument();
+  });
+
+  it("hides the demo credentials banner in production", () => {
+    setNodeEnv("production");
+    render(<LoginPage />);
+    expect(screen.queryByText(/demo@example\.com/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/password123/)).not.toBeInTheDocument();
+  });
+
+  it("renders the email input regardless of environment", () => {
+    setNodeEnv("production");
+    render(<LoginPage />);
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -90,11 +90,13 @@ export default function LoginPage() {
         </p>
       </div>
 
-      <div className="bg-orange-50 px-8 py-4 border-t border-orange-100">
-        <p className="text-xs text-center text-gray-500">
-          Demo: <span className="font-mono">demo@example.com</span> / <span className="font-mono">password123</span>
-        </p>
-      </div>
+      {process.env.NODE_ENV !== "production" && (
+        <div className="bg-orange-50 px-8 py-4 border-t border-orange-100">
+          <p className="text-xs text-center text-gray-500">
+            Demo: <span className="font-mono">demo@example.com</span> / <span className="font-mono">password123</span>
+          </p>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
The login page shows `Demo: demo@example.com / password123` to make local sign-in fast. On a public deploy that banner is a free hint for anyone who lands on `/login`. Gate it on `process.env.NODE_ENV !== "production"` so it stays in dev/test runs and disappears from the shipped bundle.

Next.js inlines `NODE_ENV` at build time, so in production the JSX dead-codes out entirely — it's not just hidden via CSS, it's not in the HTML or JS at all.

## Drive-by
Fix typecheck on \`src/__tests__/api/tasks-filtering.test.ts\` — the fixture was missing \`themePreference\` (added to \`User\` by #19). \`npm test\` didn't catch it but \`npx tsc --noEmit\` (and CI) did.

## Test plan
- [x] 4 new tests in \`LoginPage.test.tsx\`: shows in dev / shows in test / hidden in production / form still renders in production
- [x] \`npm test\` — 358/358 passing
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — succeeds with the conditional dead-coded out
- [ ] Verify on the production URL after merge: load \`/login\` in incognito, banner is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)