### PR TITLE
chore(release): set bootstrap-sha to skip legacy merge commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "bootstrap-sha": "f4a7b80",
   "packages": {
     ".": {
       "package-name": "limelight",
@@ -10,7 +11,8 @@
       "draft": false,
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": false,
+      "bootstrap-sha": "f4a7b80"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary
release-please has been failing on every push to main since #17 merged. Error:
\`\`\`
Error: unexpected token ' ' at 1:6
\`\`\`
The position (line 1, col 6) is right after \`Merge \` — release-please is trying to parse pre-squash-merge commits like \`Merge pull request #17 from MARYALA29/chore/semver-releases\` as Conventional Commits, which they aren't.

## Fix
Set \`bootstrap-sha: f4a7b80\` (the last legacy merge commit) at both the root and package level of \`release-please-config.json\`. release-please will treat that sha as the synthetic "last release" and only scan commits after it — all of which are clean Conventional Commits from squash-merges.

## Why both root and package level
release-please honors `bootstrap-sha` at either scope, but the per-package value wins for monorepo-style configs even on a single-package setup. Setting both is the safest minimal config.

## Test plan
- [ ] After merge, the next push to \`main\` triggers \`Release\` workflow → succeeds (no more parse error)
- [ ] release-please opens a "release PR" for \`v0.2.0\` (or whatever it computes from the recent feat/fix commits since f4a7b80)
- [ ] No code changes — only \`release-please-config.json\` is touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)