### PR TITLE
chore(release): use full sha for bootstrap-sha + add last-release-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "bootstrap-sha": "f4a7b80",
+  "bootstrap-sha": "f4a7b8082be76880b5dbcc6988cdf806cb56e54b",
+  "last-release-sha": "f4a7b8082be76880b5dbcc6988cdf806cb56e54b",
   "packages": {
     ".": {
       "package-name": "limelight",
@@ -11,8 +12,7 @@
       "draft": false,
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false,
-      "bootstrap-sha": "f4a7b80"
+      "bump-patch-for-minor-pre-major": false
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary
PR #25 set \`bootstrap-sha: f4a7b80\` but the release-please workflow kept failing — turns out the abbreviated SHA isn't matched. release-please needs the full 40-char hash. Also added \`last-release-sha\` since that one is honored even after the first run.

## Why this should work
- \`bootstrap-sha\`: \`f4a7b8082be76880b5dbcc6988cdf806cb56e54b\` is the last "Merge pull request #N" commit on main. Everything after it is a clean Conventional Commit from squash-merging.
- \`last-release-sha\`: same value — explicitly tells release-please "treat this as your previous release boundary, scan only commits after it."
- Removed the duplicate \`bootstrap-sha\` from the package-level config; for a single-package setup the root-level value is sufficient.

## Test plan
- [ ] After merge, the next push to main triggers Release workflow → succeeds (no more parse error)
- [ ] release-please opens a v0.2.0 release PR with the changelog of all post-bootstrap feat: / fix: / etc commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)